### PR TITLE
Remove explicit links to potentially inaccessible ITER JIRA system

### DIFF
--- a/docs/dd_developer_guide.rst
+++ b/docs/dd_developer_guide.rst
@@ -1035,10 +1035,10 @@ applying the same conversion on the errorbar nodes as on the main node.
 Adding node creation tag in the DD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Following the feature request `<https://jira.iter.org/browse/IMAS-3696>`_, it is
-decided to start introducing metadata indicating after which tag a node has been
-created/introduced in the DD. In case of a structure node, this information
-applies by default to all its descendants.
+Following a feature request, it was decided to introduce metadata
+indicating after which tag a node has been introduced into the DD. In
+case of a structure node, this information applies by default to all
+of its descendants.
 
 This done with the following metadata, to be located within the
 ``<appinfo>`` tag of the node:

--- a/docs/identifiers.rst
+++ b/docs/identifiers.rst
@@ -22,6 +22,6 @@ The list of possible labels for a given identifier structures can be found in th
 structure is applicable.
 
 The use of private indices or names in identifiers structure is discouraged, since this
-would defeat the purpose of having a standard enumerated list. Please create a `GitHub issue
-<https://github.com/iterorganization/imas-data-dictionary/issues>`_ when you want to add a
+would defeat the purpose of having a standard enumerated list. Please create a new discussion in `proposed changes 
+<https://github.com/iterorganization/imas-data-dictionary/discussions/categories/proposed-changes>`_ when you want to add a
 new identifier value.

--- a/docs/identifiers.rst
+++ b/docs/identifiers.rst
@@ -22,5 +22,6 @@ The list of possible labels for a given identifier structures can be found in th
 structure is applicable.
 
 The use of private indices or names in identifiers structure is discouraged, since this
-would defeat the purpose of having a standard enumerated list. Please create a `JIRA
-<https://jira.iter.org/>`_ tracker when you want to add a new identifier value.
+would defeat the purpose of having a standard enumerated list. Please create a `GitHub issue
+<https://github.com/iterorganization/imas-data-dictionary/issues>`_ when you want to add a
+new identifier value.


### PR DESCRIPTION
Update general link to JIRA with link to GitHub issues associated with this repo and reword text to avoid linking to explicit JIRA issue.