### PR TITLE
PyPI publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -50,6 +50,7 @@ jobs:
       
   publish-to-testpypi:
     name: Publish imas-data-dictionary distribution to TestPyPI
+    if: github.ref=='refs/heads/develop'  # only publish to TestPyPI on develop pushes
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,73 @@
+name: build-wheel-and-publish-test-pypi
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+  publish-to-pypi:
+    name: Publish imas-data-dictionary distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/imas-data-dictionary
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      
+  publish-to-testpypi:
+    name: Publish imas-data-dictionary distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/imas-data-dictionary
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@unstable/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ homepage = "https://github.com/iterorganization/imas-data-dictionary"
 
 [tool.setuptools_scm]
 write_to = "data_dictionary/_version.py"
+local_scheme = "no-local-version"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
Add a github actions workflow to build a distribution and publish it on pypi (on tags) and test.pypi (pushes to the `develop` branch).