### PR TITLE
[IMAS-5246] Adhere to udunits and resolve as_parent units

### DIFF
--- a/dd_data_dictionary.xml.xsl
+++ b/dd_data_dictionary.xml.xsl
@@ -215,6 +215,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 		<xsl:param name="parentCoordinate4"/>
 		<xsl:param name="parentCoordinate5"/>
 		<xsl:param name="parentCoordinate6"/>
+		<xsl:param name="parentUnits"/>
 		<!-- Start implementing all child elements of the complexType -->
 		<xsl:apply-templates select="*/xs:element" mode="IMPLEMENT">
 			<xsl:with-param name="currPath" select="$currPath"/>
@@ -228,6 +229,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 			<xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/>
 			<xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/>
 			<xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/>
+			<xsl:with-param name="parentUnits" select="$parentUnits"/>
 		</xsl:apply-templates>
 	</xsl:template>
 	<!-- Handle element definition in implement mode. Here all data types are checked -->
@@ -242,6 +244,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 		<xsl:param name="parentCoordinate4"/>
 		<xsl:param name="parentCoordinate5"/>
 		<xsl:param name="parentCoordinate6"/>
+		<xsl:param name="parentUnits"/>
 		<xsl:param name="structure_reference"/>
 		<xsl:choose>
 			<!-- If it is an external reference -->
@@ -299,7 +302,9 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 							<xsl:attribute name="data_type"><xsl:value-of select="xs:complexType/xs:group/@ref"/></xsl:attribute>
 							<xsl:for-each select="xs:annotation/xs:appinfo/*">
 								<!-- Generic method for declaring all appinfo as attributes-->
-								<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
+								<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when>
+								<!-- Resolve as_parent(_level_2) units -->
+								<xsl:when test="name(.) = 'units' and contains(., 'as_parent') and $parentUnits != ''"><xsl:value-of select="$parentUnits"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
 								<!-- Write a timebasepath attribute (coordinate path relative to the nearest AoS parent) in case the appinfo is a coordinate to a timebase -->
 								<xsl:if test="contains(lower-case(name(.)),'coordinate') and ends-with(.,'time')">
 									<xsl:attribute name="timebasepath"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/><xsl:with-param name="utilities_aoscontext" select="../utilities_aoscontext"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:attribute>
@@ -325,7 +330,9 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 								<xsl:attribute name="data_type"><xsl:value-of select="xs:complexType/xs:group/@ref"/></xsl:attribute>
 								<xsl:for-each select="xs:annotation/xs:appinfo/*[not(contains(name(.),'alternative_coordinate'))]">
 									<!-- Generic method for declaring all appinfo as attributes, but don't propagate the alternative_coordinate attribute to the errorbar nodes -->
-									<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_upper'"/></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_upper'"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
+									<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_upper'"/></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_upper'"/></xsl:when>
+									<!-- Resolve as_parent(_level_2) units -->
+									<xsl:when test="name(.) = 'units' and contains(., 'as_parent') and $parentUnits != ''"><xsl:value-of select="$parentUnits"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
 									<!-- Write a timebasepath attribute (coordinate path relative to the nearest AoS parent) in case the appinfo is a coordinate to a timebase -->
 									<xsl:if test="contains(lower-case(name(.)),'coordinate') and (ends-with(.,'time') or ../../../@name='time')">
 										<xsl:attribute name="timebasepath"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/><xsl:with-param name="utilities_aoscontext" select="../utilities_aoscontext"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:attribute>
@@ -349,7 +356,9 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 								<xsl:attribute name="data_type"><xsl:value-of select="xs:complexType/xs:group/@ref"/></xsl:attribute>
 								<xsl:for-each select="xs:annotation/xs:appinfo/*[not(contains(name(.),'alternative_coordinate'))]">
 									<!-- Generic method for declaring all appinfo as attributes, but don't propagate the alternative_coordinate attribute to the errorbar nodes -->
-									<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_lower'"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
+									<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:when test="contains(name(.),'change_nbc_previous_name')"><xsl:value-of select="."/><xsl:value-of select="'_error_lower'"/></xsl:when>
+									<!-- Resolve as_parent(_level_2) units -->
+									<xsl:when test="name(.) = 'units' and contains(., 'as_parent') and $parentUnits != ''"><xsl:value-of select="$parentUnits"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
 									<!-- Write a timebasepath attribute (coordinate path relative to the nearest AoS parent) in case the appinfo is a coordinate to a timebase -->
 									<xsl:if test="contains(lower-case(name(.)),'coordinate') and (ends-with(.,'time') or ../../../@name='time')">
 										<xsl:attribute name="timebasepath"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/><xsl:with-param name="utilities_aoscontext" select="../utilities_aoscontext"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildRelativeAosParentPath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="aosLevel" select="$aosLevel - 1"/><xsl:with-param name="structure_reference" select="$structure_reference"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:attribute>
@@ -393,7 +402,9 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 											</xsl:choose>
 											<xsl:for-each select="xs:annotation/xs:appinfo/*">
 												<!-- Generic method for declaring all appinfo as attributes. There is a long, special treatement for coordinates because the path is indicated, otherwise treatment is just copying the attribute (see the value-of select . at the very end ...) -->
-												<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="../type='dynamic'"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat(../../../@name,'(itime)')"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name,'(itime)')"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:otherwise><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat(../../../@name,'($aosLevel)')"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name,'($aosLevel)')"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:otherwise></xsl:choose></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
+												<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="../type='dynamic'"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat(../../../@name,'(itime)')"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name,'(itime)')"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:otherwise><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat(../../../@name,'($aosLevel)')"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name,'($aosLevel)')"/><xsl:with-param name="coordinatePath" select="."/><xsl:with-param name="parentCoordinate1" select="$parentCoordinate1"/><xsl:with-param name="parentCoordinate2" select="$parentCoordinate2"/><xsl:with-param name="parentCoordinate3" select="$parentCoordinate3"/><xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/><xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/><xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:otherwise></xsl:choose></xsl:when>
+												<!-- Resolve as_parent(_level_2) units -->
+												<xsl:when test="name(.) = 'units' and contains(., 'as_parent') and $parentUnits != ''"><xsl:value-of select="$parentUnits"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
 											</xsl:for-each>
 										</xsl:when>
 										<!-- It is a regular structure -->
@@ -409,10 +420,23 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 											</xsl:choose>
 											<xsl:for-each select="xs:annotation/xs:appinfo/*">
 												<!-- Generic method for declaring all appinfo as attributes. There is a long, special treatement for coordinates because the path is indicated, otherwise treatment is just copying the attribute (see the value-of select . at the very end ...) -->
-												<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
+												<xsl:attribute name="{lower-case(name(.))}"><xsl:choose><xsl:when test="contains(lower-case(name(.)),'coordinate')"><xsl:choose><xsl:when test="$currPath=''"><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="../../../@name"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:when><xsl:otherwise><xsl:call-template name="BuildAbsolutePath"><xsl:with-param name="coordinate" select="lower-case(name(.))"/><xsl:with-param name="currPath" select="concat($currPath_doc,'/',../../../@name)"/><xsl:with-param name="coordinatePath" select="."/></xsl:call-template></xsl:otherwise></xsl:choose></xsl:when>
+												<!-- Resolve as_parent(_level_2) units -->
+												<xsl:when test="name(.) = 'units' and contains(., 'as_parent') and $parentUnits != ''"><xsl:value-of select="$parentUnits"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:attribute>
 											</xsl:for-each>
 										</xsl:otherwise>
 									</xsl:choose>
+									<!-- select the units that (grand) children use when their unit is 'as_parent': -->
+									<xsl:variable name="parentUnitsForChild">
+										<xsl:choose>
+											<xsl:when test="contains(xs:annotation/xs:appinfo/units, 'as_parent') or string(xs:annotation/xs:appinfo/units) = ''">
+												<xsl:value-of select="$parentUnits"/> <!-- propagate parent units to grandchildren -->
+											</xsl:when>
+											<xsl:otherwise> <!-- propagate current node units children -->
+												<xsl:value-of select="xs:annotation/xs:appinfo/units"/>
+											</xsl:otherwise>
+										</xsl:choose>
+									</xsl:variable>
 									<!-- Handle type definition via template doImplementType. Need to pass an appropriate path definition -->
 									<xsl:choose>
 										<xsl:when test="$currPath=''">
@@ -432,6 +456,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 																<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 																<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 																<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+																<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 															</xsl:call-template>
 														</xsl:when>
 														<xsl:otherwise>
@@ -447,6 +472,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 																<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 																<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 																<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+																<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 															</xsl:call-template>
 														</xsl:otherwise>
 													</xsl:choose>
@@ -464,6 +490,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 														<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 														<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 														<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+														<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 													</xsl:call-template>
 												</xsl:otherwise>
 											</xsl:choose>
@@ -485,6 +512,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 																<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 																<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 																<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+																<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 															</xsl:call-template>
 														</xsl:when>
 														<xsl:otherwise>
@@ -500,6 +528,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 																<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 																<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 																<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+																<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 															</xsl:call-template>
 														</xsl:otherwise>
 													</xsl:choose>
@@ -517,6 +546,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 														<xsl:with-param name="parentCoordinate4" select="xs:annotation/xs:appinfo/coordinate4"/>
 														<xsl:with-param name="parentCoordinate5" select="xs:annotation/xs:appinfo/coordinate5"/>
 														<xsl:with-param name="parentCoordinate6" select="xs:annotation/xs:appinfo/coordinate6"/>
+														<xsl:with-param name="parentUnits" select="$parentUnitsForChild"/>
 													</xsl:call-template>
 												</xsl:otherwise>
 											</xsl:choose>
@@ -651,6 +681,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 		<xsl:param name="parentCoordinate4"/>
 		<xsl:param name="parentCoordinate5"/>
 		<xsl:param name="parentCoordinate6"/>
+		<xsl:param name="parentUnits"/>
 		<xsl:param name="structure_reference"/>
 		<xsl:choose>
 			<xsl:when test="document('schemas/utilities/dd_support.xsd')/*/xs:complexType[@name=$thisType]">
@@ -668,6 +699,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 					<xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/>
 					<xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/>
 					<xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/>
+					<xsl:with-param name="parentUnits" select="$parentUnits"/>
 				</xsl:apply-templates>
 			</xsl:when>
 			<xsl:when test="/*/xs:complexType[@name=$thisType]">
@@ -684,6 +716,7 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 					<xsl:with-param name="parentCoordinate4" select="$parentCoordinate4"/>
 					<xsl:with-param name="parentCoordinate5" select="$parentCoordinate5"/>
 					<xsl:with-param name="parentCoordinate6" select="$parentCoordinate6"/>
+					<xsl:with-param name="parentUnits" select="$parentUnits"/>
 				</xsl:apply-templates>
 			</xsl:when>
 		</xsl:choose>

--- a/dd_data_dictionary_validation.txt.xsl
+++ b/dd_data_dictionary_validation.txt.xsl
@@ -73,7 +73,7 @@ The utilities section has errors:<xsl:apply-templates select="./utilities//field
 <xsl:with-param name="error_description" select="'This field must have a units attribute'"/>
 </xsl:apply-templates>
 <!-- Test that INT and STR data have no "units" metadata (R5.3), although some exceptions are possible for specific cases (UTC, Elementary charge or atomic mass units) -->
-<xsl:apply-templates select=".//field[@units and not(@units='UTC' or @units='Atomic Mass Unit' or @units='Elementary Charge Unit') and (contains(@data_type,'STR_') or contains(@data_type,'INT_') or contains(@data_type,'str_') or contains(@data_type,'int_'))]">
+<xsl:apply-templates select=".//field[@units and not(@units='UTC' or @units='u' or @units='e') and (contains(@data_type,'STR_') or contains(@data_type,'INT_') or contains(@data_type,'str_') or contains(@data_type,'int_'))]">
 <xsl:with-param name="error_description" select="'This field should NOT have a units attribute'"/>
 </xsl:apply-templates>
 <!-- Test the presence of nested AoS 3 (illegal) -->

--- a/docs/dd_developer_guide.rst
+++ b/docs/dd_developer_guide.rst
@@ -543,7 +543,14 @@ The detailed meaning of each property can be found in the
 :ref:`dm_rules_guidelines`. In particular sections :ref:`Self-description
 Conventions` and :ref:`List of the existing data types`.
 
-NB: ``FLT_*`` and ``CPX_*`` nodes will have sibling errorbar nodes automatically generated
+NB1: units are normally explicitly defined at the level of the leaf node.
+However, in the case of node belonging to a structure that can be used in different contexts,
+it's possible to refer to the units of the parent node by indicating ``<units>as_parent</units>``.
+It's also possible to refer to the units of the grand-parent node with 
+``<units>as_parent_level_2</units>``. The references will be explicitly resolved 
+when generating the ``dd_data_dictionary.xml`` file.
+
+NB2: ``FLT_*`` and ``CPX_*`` nodes will have sibling errorbar nodes automatically generated
 when generating the dd_data_dictionary.xml file. To avoid this, for performance reasons
 (e.g. in large size GGD objects), the data type of the leaf should be declared in a different way,
 using the simpleTypes defined in utilities.xsd (named flt_type and flt_nd_type). Example:
@@ -587,6 +594,9 @@ An example from the core_profiles IDS:
          </xs:documentation>
       </xs:annotation>
    </xs:element>
+
+Structure nodes shouldn't have units, unless these are refered to by descendent
+leaf nodes (see ``<units>as_parent</units>`` case above)
 
 Note that the previous (from DD tags 3.0.0 to 3.21.0) way of declaring
 signals (data, time structures with their own time bases) is deprecated.
@@ -781,7 +791,7 @@ absolute path when generating the dd_data_dictionary.xml file.
             <type>dynamic</type>
             <coordinate1>1...N</coordinate1>
             <alternative_coordinate1>../rho_tor;../psi;../volume;../area;../surface;../rho_pol_norm</alternative_coordinate1>
-            <units>-</units>
+            <units>1</units>
          </xs:appinfo>
       </xs:annotation>
       <xs:complexType>
@@ -1142,7 +1152,9 @@ following attributes:
 
 -  ``coordinate1`` ... ``coordinateN``: N attributes listing the coordinates of
    the node (absolute paths, i.e. relative to the root of the IDS)
--  ``units``: units of the node
+-  ``units``: units of the node. In case the units in the IDS schema refer 
+   to the parent or grandparent node, these references are explicitly resolved
+   in the ``dd_data_dictionary.xml`` file
 -  ``lifecycle_status``: lifecycle status as defined in the DD lifecycle
    document
 -  ``lifecycle_version``: version of the DD since which this node has this

--- a/docs/dd_developer_guide.rst
+++ b/docs/dd_developer_guide.rst
@@ -544,13 +544,13 @@ The detailed meaning of each property can be found in the
 Conventions` and :ref:`List of the existing data types`.
 
 NB1: units are normally explicitly defined at the level of the leaf node.
-However, in the case of node belonging to a structure that can be used in different contexts,
+However, in the case of a node belonging to a structure that can be used in different contexts,
 it's possible to refer to the units of the parent node by indicating ``<units>as_parent</units>``.
-It's also possible to refer to the units of the grand-parent node with 
+It's also possible to refer to the units of the grandparent node with 
 ``<units>as_parent_level_2</units>``. The references will be explicitly resolved 
 when generating the ``dd_data_dictionary.xml`` file.
 
-NB2: ``FLT_*`` and ``CPX_*`` nodes will have sibling errorbar nodes automatically generated
+NB2: ``FLT_*`` and ``CPX_*`` nodes will have sibling errorbar nodes automatically created
 when generating the dd_data_dictionary.xml file. To avoid this, for performance reasons
 (e.g. in large size GGD objects), the data type of the leaf should be declared in a different way,
 using the simpleTypes defined in utilities.xsd (named flt_type and flt_nd_type). Example:

--- a/docs/dm_rules_guidelines.rst
+++ b/docs/dm_rules_guidelines.rst
@@ -526,7 +526,7 @@ developer.
 
    *  -  R5.3
       -  Float and Complex data items shall have their units defined. If the
-         quantity is dimensionless, the units shall be ``-``. if the quantity has
+         quantity is dimensionless, the units shall be ``1``. if the quantity has
          mixed units, then the units shall be ``mixed``.
 
          If the quantity is implemented via a generic structure with its
@@ -537,7 +537,8 @@ developer.
          The units of a quantity shall be self-described in the Data Dictionary
          under the XML ``<appinfo>`` metadata using the SI system plus ``eV``,
          ``rad`` for angles, UTC for absolute time, days /weeks / months / years
-         for durations.
+         for durations. Units shall follow the `UDUNITS2
+         <https://docs.unidata.ucar.edu/udunits/current/>`__ convention.
 
          The XML syntax for units is :code:`<units>Wb</units>`.
          

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -10,7 +10,7 @@ On the reference pages, units are indicated between square brackets.
 Dimensionless units
 '''''''''''''''''''
 
-Dimensionless quantities have ``-`` indicated as their unit.
+Dimensionless quantities have ``1`` indicated as their unit.
 
 
 Use case dependent units
@@ -19,15 +19,3 @@ Use case dependent units
 Some quantities have use case dependent units, for example
 :dd:node:`controllers/linear_controller/pid/p`. The units for these quantities are
 indicated as ``mixed``.
-
-
-``as_parent`` units
-'''''''''''''''''''
-
-.. todo:: check if we can resolve these during generation
-
-The Data Dictionary can also indicate that a quantity has the same units as
-their parent structure, for example
-:dd:node:`core_profiles/profiles_1d/ion/velocity/radial`. Those units are
-indicated as ``as_parent`` and you can check the parent structure for their
-units (:math:`\mathrm{m}\cdot\mathrm{s}^{-1}` in this example).

--- a/schemas/amns_data/dd_amns_data.xsd
+++ b/schemas/amns_data/dd_amns_data.xsd
@@ -117,7 +117,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of the participant</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>static</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -129,7 +129,7 @@
 				<xs:annotation>
 					<xs:documentation>Charge number of the participant</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>static</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -152,7 +152,7 @@
 				<xs:annotation>
 					<xs:documentation>Multiplicity in the reaction</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>static</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -208,7 +208,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>static</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -220,7 +220,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>static</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -601,7 +601,7 @@
 					<xs:annotation>
 						<xs:documentation>Nuclear charge</xs:documentation>
 						<xs:appinfo>
-							<units>Elementary Charge Unit</units>
+							<units>e</units>
 							<type>static</type>
 							<change_nbc_version>4.0.0</change_nbc_version>
 							<change_nbc_description>type_changed</change_nbc_description>
@@ -616,7 +616,7 @@
 					<xs:annotation>
 						<xs:documentation>Mass of atom</xs:documentation>
 						<xs:appinfo>
-							<units>Atomic Mass Unit</units>
+							<units>u</units>
 							<type>static</type>
 						</xs:appinfo>
 					</xs:annotation>

--- a/schemas/b_field_non_axisymmetric/dd_b_field_non_axisymmetric.xsd
+++ b/schemas/b_field_non_axisymmetric/dd_b_field_non_axisymmetric.xsd
@@ -188,7 +188,7 @@
 					<xs:documentation>Value of (b_field_max-b_field_min)/(b_field_max+b_field_min), where b_field_max resp. b_field_min) is the maximum (resp. minimum) of the magnetic field amplitude over a 2pi rotation in toroidal angle phi at a given R, Z position. </xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../grid/r</coordinate1>
 						<coordinate2>../grid/z</coordinate2>
 					</xs:appinfo>

--- a/schemas/bremsstrahlung_visible/dd_bremsstrahlung_visible.xsd
+++ b/schemas/bremsstrahlung_visible/dd_bremsstrahlung_visible.xsd
@@ -34,7 +34,7 @@
 				<xs:annotation>
 					<xs:documentation>Intensity, i.e. number of photoelectrons detected by unit time, taking into account electronic gain compensation and channels relative calibration</xs:documentation>
 					<xs:appinfo>
-						<units>(counts) s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -42,7 +42,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated spectral radiance (radiance per unit wavelength)</xs:documentation>
 					<xs:appinfo>
-						<units>(photons).m^-2.s^-1.sr^-1.m^-1</units>
+						<units>m^-2.s^-1.sr^-1.m^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -50,7 +50,7 @@
 				<xs:annotation>
 					<xs:documentation>Average effective charge along the line of sight</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/camera_visible/dd_camera_visible.xsd
+++ b/schemas/camera_visible/dd_camera_visible.xsd
@@ -201,7 +201,7 @@
 						<coordinate1_same_as>../image_raw</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
 						<coordinate2_same_as>../image_raw</coordinate2_same_as>
-						<units>photons.m^-2.s^-1.sr^-1</units>
+						<units>m^-2.s^-1.sr^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -284,7 +284,7 @@
 						<coordinate1_same_as>../frame(itime)/image_raw</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
 						<coordinate2_same_as>../frame(itime)/image_raw</coordinate2_same_as>
-						<units>photons.m^-2.s^-1.sr^-1.counts^-1</units>
+						<units>m^-2.s^-1.sr^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -308,7 +308,7 @@
 					<xs:documentation>Detector noise (e.g. read-out noise) (rms counts per second exposure time)</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/camera_x_rays/dd_camera_x_rays.xsd
+++ b/schemas/camera_x_rays/dd_camera_x_rays.xsd
@@ -100,7 +100,7 @@
 							<coordinate2>1...N</coordinate2>
 							<coordinate2_same_as>../frame(itime)/counts_n OR 1...1</coordinate2_same_as>
 							<coordinate3>../photon_energy</coordinate3>
-							<units>-</units>
+							<units>1</units>
 						</xs:appinfo>
 					</xs:annotation>
 					<xs:complexType>
@@ -204,7 +204,7 @@
 					<xs:annotation>
 						<xs:documentation>Fraction of humidity (0-1) measured at the detector level</xs:documentation>
 						<xs:appinfo>
-							<units>-</units>
+							<units>1</units>
 						</xs:appinfo>
 					</xs:annotation>
 				</xs:element>

--- a/schemas/charge_exchange/dd_charge_exchange.xsd
+++ b/schemas/charge_exchange/dd_charge_exchange.xsd
@@ -48,7 +48,7 @@
 				<xs:annotation>
 					<xs:documentation>Non-calibrated intensity (integrated over the spectrum for this line), i.e. number of photoelectrons detected by unit time, taking into account electronic gain compensation and channels relative calibration</xs:documentation>
 					<xs:appinfo>
-						<units>(photonelectrons).s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -142,7 +142,7 @@
 				<xs:annotation>
 					<xs:documentation>Intensity spectrum (not calibrated), i.e. number of photoelectrons detected by unit time by a wavelength pixel of the channel, taking into account electronic gain compensation and channels relative calibration</xs:documentation>
 					<xs:appinfo>
-						<units>(photoelectrons).s^-1</units>
+						<units>s^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -152,7 +152,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated spectral radiance (radiance per unit wavelength)</xs:documentation>
 					<xs:appinfo>
-						<units>(photons) m^-2.s^-1.sr^-1.m^-1</units>
+						<units>m^-2.s^-1.sr^-1.m^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -222,7 +222,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom of the fast ion</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -235,7 +235,7 @@
 					<xs:documentation>Fast ion charge</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -246,7 +246,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge of the fast ion</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -287,7 +287,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated radiance of the fast ion charge exchange spectrum assuming the shape is pre-defined (e.g. by the Fokker-Planck slowing-down function). Note: radiance is integrated over the sightline crossing the neutral beam</xs:documentation>
 					<xs:appinfo>
-						<units>(photons) m^-2.s^-1.sr^-1</units>
+						<units>m^-2.s^-1.sr^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -307,7 +307,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom of the ion</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -320,7 +320,7 @@
 					<xs:documentation>Ion charge</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -331,7 +331,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -408,7 +408,7 @@
 				<xs:annotation>
 					<xs:documentation>Ion concentration (ratio of the ion density over the electron density) at the channel measurement point</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -428,7 +428,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom of the diagnostic neutral beam particle</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -441,7 +441,7 @@
 					<xs:documentation>Ion charge of the diagnostic neutral beam particle</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -452,7 +452,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge of the diagnostic neutral beam particle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -509,7 +509,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated intensities of the 9 splitted lines (Stark effect due to Lorentz electric field). Note: radiances are integrated over the sightline crossing the neutral beam</xs:documentation>
 					<xs:appinfo>
-						<units>(photons) m^-2.s^-1.sr^-1</units>
+						<units>m^-2.s^-1.sr^-1</units>
 						<coordinate1>1...9</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -567,7 +567,7 @@
 				<xs:annotation>
 					<xs:documentation>Local ionic effective charge at the channel measurement point</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -580,7 +580,7 @@
 				<xs:annotation>
 					<xs:documentation>Ionic effective charge, line average along the channel line-of-sight</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -663,7 +663,7 @@
 						<xs:documentation>Etendue (geometric extent) of the optical system</xs:documentation>
 						<xs:appinfo>
 							<type>static</type>
-							<units>m^2.str</units>
+							<units>m^2.sr</units>
 						</xs:appinfo>
 					</xs:annotation>
 					<xs:complexType>

--- a/schemas/core_profiles/dd_core_profiles.xsd
+++ b/schemas/core_profiles/dd_core_profiles.xsd
@@ -112,7 +112,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -125,7 +125,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -138,7 +138,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -151,7 +151,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -176,7 +176,7 @@
 					<xs:documentation>Volume average plasma effective charge, estimated from the flux consumption in the ohmic phase</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -189,7 +189,7 @@
 					<xs:documentation>Electron temperature peaking factor, defined as the Te value at the magnetic axis divided by the volume averaged Te (average over the plasma volume up to the LCFS)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -202,7 +202,7 @@
 					<xs:documentation>Ion temperature (averaged over ion species and states) peaking factor, defined as the Ti value at the magnetic axis divided by the volume averaged Ti (average over the plasma volume up to the LCFS)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -229,7 +229,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -374,7 +374,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -386,7 +386,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -398,7 +398,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the charge state bundle, volume averaged over the plasma radius (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -410,7 +410,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the charge state bundle, volume averaged over the plasma radius (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -462,7 +462,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -627,7 +627,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -860,7 +860,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/dim1</coordinate1>
 						<coordinate2>../grid/dim2</coordinate2>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -906,7 +906,7 @@
 						<coordinate1>../grid/dim1</coordinate1>
 						<coordinate2>../grid/dim2</coordinate2>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/core_sources/dd_core_sources.xsd
+++ b/schemas/core_sources/dd_core_sources.xsd
@@ -258,7 +258,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -495,7 +495,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -507,7 +507,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -533,7 +533,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -647,7 +647,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1086,7 +1086,7 @@
 				<xs:annotation>
 					<xs:documentation>Total ion particle source (summed over ion  species)</xs:documentation>
 					<xs:appinfo>
-						<units>(ions).s^-1</units>
+						<units>s^-1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/core_transport/dd_core_transport.xsd
+++ b/schemas/core_transport/dd_core_transport.xsd
@@ -517,7 +517,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -529,7 +529,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -555,7 +555,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -625,7 +625,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -685,7 +685,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -961,7 +961,7 @@
 					<xs:documentation>Multiplier applied to the particule flux when adding its contribution in the expression of the heat flux : can be 0, 3/2 or 5/2</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/distributions/dd_distributions.xsd
+++ b/schemas/distributions/dd_distributions.xsd
@@ -141,7 +141,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -153,7 +153,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -190,7 +190,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -283,7 +283,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -481,7 +481,7 @@
 					<xs:documentation>Number of particles in the distribution, i.e. the volume integral of the density (note: this is the number of real particles and not markers)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -493,7 +493,7 @@
 					<xs:documentation>Number of fast particles in the distribution, i.e. the volume integral of the density (note: this is the number of real particles and not markers)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -811,7 +811,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -944,7 +944,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1068,7 +1068,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1080,7 +1080,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1117,7 +1117,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1209,7 +1209,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1221,7 +1221,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1258,7 +1258,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1684,7 +1684,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1813,7 +1813,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1933,7 +1933,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1945,7 +1945,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1982,7 +1982,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2070,7 +2070,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2082,7 +2082,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2119,7 +2119,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2771,7 +2771,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/divertors/dd_divertors.xsd
+++ b/schemas/divertors/dd_divertors.xsd
@@ -210,7 +210,7 @@
 				<xs:annotation>
 					<xs:documentation>Magnetic flux expansion as defined by Stangeby : ratio between the poloidal field at the midplane separatrix and the poloidal field at the strike-point see formula attached, where u means upstream (midplane separatrix) and t means at divertor target (downstream).</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>divertors/flux_expansion.png</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -268,7 +268,7 @@
 				<xs:annotation>
 					<xs:documentation>Power fraction incident on the target (normalized to the total power incident on the divertor)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/ec_launchers/dd_ec_launchers.xsd
+++ b/schemas/ec_launchers/dd_ec_launchers.xsd
@@ -202,7 +202,7 @@
 					<xs:documentation>Fraction of EC beam power launched in ordinary (O) mode. If all power is launched in ordinary mode (O-mode), o_mode_fraction = 1.0. If all  power is launched in extraordinary mode (X-mode), o_mode_fraction = 0.0</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 						<introduced_after_version>3.39.0</introduced_after_version>
 					</xs:appinfo>

--- a/schemas/ece/dd_ece.xsd
+++ b/schemas/ece/dd_ece.xsd
@@ -343,7 +343,7 @@
 				<xs:annotation>
 					<xs:documentation>Optical depth of the plasma at the position of the measurement. This parameter is a proxy for the local / non-local character of the ECE emission. It must be greater than 1 to guarantee that the measurement is dominated by local ECE emission (non-local otherwise)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/edge_profiles/dd_edge_profiles.xsd
+++ b/schemas/edge_profiles/dd_edge_profiles.xsd
@@ -243,7 +243,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -269,7 +269,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -348,10 +348,10 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values</xs:documentation>
+					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -420,7 +420,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate of each measurement (local value for a local measurement, minimum value reached by the line of sight for a line measurement)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -433,7 +433,7 @@
 					<xs:documentation>Normalized poloidal flux coordinate of each measurement (local value for a local measurement, minimum value reached by the line of sight for a line measurement)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -446,7 +446,7 @@
 					<xs:documentation>Weight given to each measured value</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -456,10 +456,10 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -472,7 +472,7 @@
 					<xs:documentation>Squared error normalized by the weighted standard deviation considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -505,7 +505,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -517,7 +517,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -529,7 +529,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the charge state bundle, volume averaged over the plasma radius (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -541,7 +541,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the charge state bundle, volume averaged over the plasma radius (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -554,7 +554,7 @@
 					<xs:documentation>Average charge profile of the charge state bundle (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -567,7 +567,7 @@
 					<xs:documentation>Average square charge profile of the charge state bundle (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -619,7 +619,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -786,7 +786,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -823,7 +823,7 @@
 					<xs:documentation>Average charge of the ion species (sum of states charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -836,7 +836,7 @@
 					<xs:documentation>Average square charge of the ion species (sum of states square charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1065,7 +1065,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1519,7 +1519,7 @@
 					<xs:documentation>Collisionality normalized to the bounce frequency</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1589,7 +1589,7 @@
 					<xs:documentation>Ratio of total ion density (sum over species and charge states) over electron density. (thermal+non-thermal)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1632,7 +1632,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1643,7 +1643,7 @@
 				<xs:annotation>
 					<xs:documentation>Information on the fit used to obtain the zeff profile</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1704,7 +1704,7 @@
 					<xs:documentation>Total parallel current density = average(jtot.B) / B0, where B0 = edge_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1730,7 +1730,7 @@
 					<xs:documentation>Total toroidal current density = average(J_phi/R) / average(1/R)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 						<change_nbc_version>3.42.0</change_nbc_version>
 						<change_nbc_description>leaf_renamed</change_nbc_description>
@@ -1746,7 +1746,7 @@
 					<xs:documentation>Ohmic parallel current density = average(J_Ohmic.B) / B0, where B0 = edge_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1759,7 +1759,7 @@
 					<xs:documentation>Non-inductive (includes bootstrap) parallel current density = average(jni.B) / B0, where B0 = edge_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1772,7 +1772,7 @@
 					<xs:documentation>Bootstrap current density = average(J_Bootstrap.B) / B0, where B0 = edge_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1834,7 +1834,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>edge_profiles.profiles_1d{i}.q</cocos_leaf_name_aos_indices>
@@ -1849,7 +1849,7 @@
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1902,7 +1902,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2036,7 +2036,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2048,7 +2048,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2060,7 +2060,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the state bundle (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2069,7 +2069,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the state bundle (equal to z_min if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2078,7 +2078,7 @@
 				<xs:annotation>
 					<xs:documentation>Cumulative and average ionization potential to reach a given bundle. Defined as sum (x_z* (sum of Epot from z'=0 to z-1)), where Epot is the ionization potential of ion Xz_+, and x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>aos_renamed</change_nbc_description>
@@ -2115,7 +2115,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2384,7 +2384,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2527,7 +2527,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2563,7 +2563,7 @@
 				<xs:annotation>
 					<xs:documentation>Particle content = total number of particles for this ion species in the volume of the grid subset, for various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2732,7 +2732,7 @@
 					<xs:documentation>Ratio of total ion density (sum over ion species) over electron density. (thermal+non-thermal), given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2741,7 +2741,7 @@
 					<xs:documentation>Effective charge, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/edge_transport/dd_edge_transport.xsd
+++ b/schemas/edge_transport/dd_edge_transport.xsd
@@ -41,7 +41,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -144,7 +144,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -247,7 +247,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -336,7 +336,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -397,7 +397,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -409,7 +409,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -435,7 +435,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -620,7 +620,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -706,7 +706,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -929,7 +929,7 @@
 					<xs:documentation>Multiplier applied to the particule flux when adding its contribution in the expression of the heat flux : can be 0, 3/2 or 5/2</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/equilibrium/dd_equilibrium.xsd
+++ b/schemas/equilibrium/dd_equilibrium.xsd
@@ -330,7 +330,7 @@
 					<xs:documentation>Value of the normalized poloidal flux at which the boundary is taken, the flux being normalized to its value at the separatrix (so psi_norm = 1 if the boundary is the separatrix)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -371,7 +371,7 @@
 					<xs:documentation>Elongation of the plasma boundary</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -383,7 +383,7 @@
 				<xs:annotation>
 					<xs:documentation>Triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -396,7 +396,7 @@
 				<xs:annotation>
 					<xs:documentation>Upper triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -409,7 +409,7 @@
 				<xs:annotation>
 					<xs:documentation>Lower triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -423,7 +423,7 @@
 					<xs:documentation>Upper inner squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -437,7 +437,7 @@
 					<xs:documentation>Upper outer squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -451,7 +451,7 @@
 					<xs:documentation>Lower inner squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -465,7 +465,7 @@
 					<xs:documentation>Lower outer squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -612,7 +612,7 @@
 					<xs:documentation>Minimum q value</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>equilibrium.time_slice{i}.global_quantities.q_min.value</cocos_leaf_name_aos_indices>
@@ -627,7 +627,7 @@
 					<xs:documentation>Minimum q position in normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -639,7 +639,7 @@
 					<xs:documentation>Minimum q position in normalised poloidal flux</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -672,7 +672,7 @@
 					<xs:documentation>Poloidal beta. Defined as betap = 4 int(p dV) / [R_0 * mu_0 * Ip^2]</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -684,7 +684,7 @@
 					<xs:documentation>Toroidal beta, defined as the volume-averaged total perpendicular pressure divided by (B0^2/(2*mu0)), i.e. beta_toroidal = 2 mu0 int(p dV) / V / B0^2</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -696,7 +696,7 @@
 					<xs:documentation>Normalized toroidal beta, defined as 100 * beta_tor * a[m] * B0 [T] / ip [MA] </xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>leaf_renamed</change_nbc_description>
 						<change_nbc_previous_name>beta_normal</change_nbc_previous_name>
@@ -726,7 +726,7 @@
 					<xs:documentation>Internal inductance</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -833,7 +833,7 @@
 					<xs:documentation>q at the magnetic axis</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>equilibrium.time_slice{i}.global_quantities.q_axis</cocos_leaf_name_aos_indices>
@@ -848,7 +848,7 @@
 					<xs:documentation>q at the 95% poloidal flux surface (only positive when toroidal current and magnetic field are in same direction)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>equilibrium.time_slice{i}.global_quantities.q_95</cocos_leaf_name_aos_indices>
@@ -980,7 +980,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1079,7 +1079,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1091,7 +1091,7 @@
 					<xs:documentation>Value calculated from the reconstructed equilibrium</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1171,7 +1171,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1198,7 +1198,7 @@
 					<xs:documentation>Squared error normalized by the variance considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1266,7 +1266,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1293,7 +1293,7 @@
 					<xs:documentation>Squared error normalized by the variance considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1361,7 +1361,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1388,7 +1388,7 @@
 					<xs:documentation>Squared error normalized by the variance considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1453,7 +1453,7 @@
 					<xs:documentation>Weight given to the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1477,7 +1477,7 @@
 					<xs:documentation>Squared error normalized by the variance considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1666,7 +1666,7 @@
 					<xs:documentation>Set of safety factor estimates at various positions</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1713,7 +1713,7 @@
 					<xs:documentation>Sum of the chi_squared of all constraints used for the equilibrium reconstruction, divided by the number of degrees of freedom of the identification model</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 						<uri>https://arxiv.org/abs/1009.2755</uri>
 					</xs:appinfo>
@@ -1772,7 +1772,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1844,7 +1844,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>T^2.m^2/Wb</units>
+						<units>T^2.m^2.Wb^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1892,7 +1892,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>equilibrium.time_slice{i}.profiles_1d.q</cocos_leaf_name_aos_indices>
@@ -1907,7 +1907,7 @@
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1960,7 +1960,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1973,7 +1973,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>Wb/m</units>
+						<units>Wb.m^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1991,7 +1991,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2005,7 +2005,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2019,7 +2019,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2033,7 +2033,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -2048,7 +2048,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -2063,7 +2063,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -2078,7 +2078,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<lifecycle_status>alpha</lifecycle_status>
 						<lifecycle_version>3.18.0</lifecycle_version>
 					</xs:appinfo>
@@ -2106,7 +2106,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2197,7 +2197,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2236,7 +2236,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2288,7 +2288,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2366,7 +2366,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../psi</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/ferritic/dd_ferritic.xsd
+++ b/schemas/ferritic/dd_ferritic.xsd
@@ -228,7 +228,7 @@
 					<xs:documentation>Relative permeability as a function of the magnetic field</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../b_field</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/focs/dd_focs.xsd
+++ b/schemas/focs/dd_focs.xsd
@@ -14,7 +14,7 @@
 					<xs:documentation>S0 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -26,7 +26,7 @@
 					<xs:documentation>S1 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -38,7 +38,7 @@
 					<xs:documentation>S2 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -50,7 +50,7 @@
 					<xs:documentation>S3 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -78,7 +78,7 @@
 					<xs:documentation>S0 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -90,7 +90,7 @@
 					<xs:documentation>S1 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -102,7 +102,7 @@
 					<xs:documentation>S2 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -114,7 +114,7 @@
 					<xs:documentation>S3 component of the unit Stokes vector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/gyrokinetics_local/dd_gyrokinetics_local.xsd
+++ b/schemas/gyrokinetics_local/dd_gyrokinetics_local.xsd
@@ -14,7 +14,7 @@
 					<xs:documentation>normalized charge</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -26,7 +26,7 @@
 					<xs:documentation>normalized mass</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -38,7 +38,7 @@
 					<xs:documentation>normalized density</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -50,7 +50,7 @@
 					<xs:documentation>normalized logarithmic gradient (with respect to r_minor_norm) of the density</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -62,7 +62,7 @@
 					<xs:documentation>normalized temperature</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -74,7 +74,7 @@
 					<xs:documentation>normalized logarithmic gradient (with respect to r_minor_norm) of the temperature</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -86,7 +86,7 @@
 					<xs:documentation>Normalized gradient (with respect to r_minor_norm) of the toroidal velocity</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -98,7 +98,7 @@
 					<xs:documentation>normalized gradient (with respect to r_minor_norm) of the effective potential energy</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 						<coordinate1>../../species_all/angle_pol_equilibrium</coordinate1>
 					</xs:appinfo>
@@ -112,7 +112,7 @@
 					<xs:documentation>Effective potential energy determining the poloidal variation of the species background density</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 						<coordinate1>../../species_all/angle_pol_equilibrium</coordinate1>
 					</xs:appinfo>
@@ -133,7 +133,7 @@
 					<xs:documentation>normalized minor radius of the flux surface of interest = 1/2 * (max(R) - min(R))/L_ref</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -145,7 +145,7 @@
 					<xs:documentation>Elongation</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -157,7 +157,7 @@
 					<xs:documentation>Derivative of the elongation with respect to r_minor_norm</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.36.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -170,7 +170,7 @@
 					<xs:documentation>Derivative of the major radius of the surface geometric axis with respect to r_minor</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.36.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -183,7 +183,7 @@
 					<xs:documentation>Derivative of the height of the surface geometric axis with respect to r_minor</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.36.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -196,7 +196,7 @@
 					<xs:documentation>Safety factor</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -208,7 +208,7 @@
 					<xs:documentation>Magnetic shear, defined as r_minor_norm/q . dq/dr_minor_norm (different definition from the equilibrium IDS)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -220,7 +220,7 @@
 					<xs:documentation>normalized pressure gradient (derivative with respect to r_minor_norm)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -232,7 +232,7 @@
 					<xs:documentation>Sign of the plasma current</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -244,7 +244,7 @@
 					<xs:documentation>Sign of the toroidal magnetic field</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -256,7 +256,7 @@
 					<xs:documentation>'c' coefficients in the formula defining the shape of the flux surface</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -269,7 +269,7 @@
 					<xs:documentation>Derivative of the 'c' shape coefficients with respect to r_minor_norm</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../shape_coefficients_c</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -282,7 +282,7 @@
 					<xs:documentation>'s' coefficients in the formula defining the shape of the flux surface</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -295,7 +295,7 @@
 					<xs:documentation>Derivative of the 's' shape coefficients with respect to r_minor_norm</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../shape_coefficients_s</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -315,7 +315,7 @@
 					<xs:documentation>Reference plasma beta (see detailed documentation at the root of the IDS)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -327,7 +327,7 @@
 					<xs:documentation>normalized toroidal velocity of species (all species are assumed to have a purely toroidal velocity with a common toroidal angular frequency)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -339,7 +339,7 @@
 					<xs:documentation>Debye length computed from the reference quantities (see detailed documentation at the root of the IDS)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -351,7 +351,7 @@
 					<xs:documentation>normalized ExB shearing rate (for non-linear runs only)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -560,7 +560,7 @@
 					<xs:documentation>normalized density</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -575,7 +575,7 @@
 					<xs:documentation>normalized parallel current density</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -590,7 +590,7 @@
 					<xs:documentation>Normalized parallel pressure</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -605,7 +605,7 @@
 					<xs:documentation>Normalized perpendicular pressure</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -620,7 +620,7 @@
 					<xs:documentation>Normalised pressure, defined as the sum of pressure_parallel and pressure_perpendicular</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -636,7 +636,7 @@
 					<xs:documentation>Normalized parallel heat flux (integral of 0.5 * m * v_par * v^2)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -651,7 +651,7 @@
 					<xs:documentation>Normalized moment (integral over 0.5 * m * v_par * v_perp^2)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -666,7 +666,7 @@
 					<xs:documentation>Normalized moment (integral over 0.5 * m * v_perp^2 * v^2)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 						<coordinate2>../../angle_pol</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -689,7 +689,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -702,7 +702,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -715,7 +715,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -736,7 +736,7 @@
 						<type>constant</type>
 						<coordinate1>../../radial_wavevector_norm</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -750,7 +750,7 @@
 						<type>constant</type>
 						<coordinate1>../../radial_wavevector_norm</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -764,7 +764,7 @@
 						<type>constant</type>
 						<coordinate1>../../radial_wavevector_norm</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -785,7 +785,7 @@
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -799,7 +799,7 @@
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -813,7 +813,7 @@
 						<type>constant</type>
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -835,7 +835,7 @@
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -850,7 +850,7 @@
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -865,7 +865,7 @@
 						<coordinate1>../../binormal_wavevector_norm</coordinate1>
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -888,7 +888,7 @@
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
 						<coordinate4>../../time_norm</coordinate4>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -904,7 +904,7 @@
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
 						<coordinate4>../../time_norm</coordinate4>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -920,7 +920,7 @@
 						<coordinate2>../../radial_wavevector_norm</coordinate2>
 						<coordinate3>../../angle_pol</coordinate3>
 						<coordinate4>../../time_norm</coordinate4>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -939,7 +939,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -952,7 +952,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -965,7 +965,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -978,7 +978,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -991,7 +991,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1004,7 +1004,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1017,7 +1017,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1030,7 +1030,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1043,7 +1043,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1056,7 +1056,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1069,7 +1069,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1082,7 +1082,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1102,7 +1102,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1116,7 +1116,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1130,7 +1130,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1144,7 +1144,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1158,7 +1158,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1172,7 +1172,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1186,7 +1186,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1200,7 +1200,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1214,7 +1214,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1228,7 +1228,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1242,7 +1242,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1256,7 +1256,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
 					</xs:appinfo>
@@ -1277,7 +1277,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1291,7 +1291,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1305,7 +1305,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1319,7 +1319,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1333,7 +1333,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1347,7 +1347,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1361,7 +1361,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1375,7 +1375,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1389,7 +1389,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1403,7 +1403,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1417,7 +1417,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1431,7 +1431,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 					</xs:appinfo>
@@ -1452,7 +1452,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalised particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1467,7 +1467,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalised particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1482,7 +1482,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalised particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1497,7 +1497,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalised energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1512,7 +1512,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalised energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1527,7 +1527,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalised energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1542,7 +1542,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1557,7 +1557,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1572,7 +1572,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1587,7 +1587,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1602,7 +1602,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1617,7 +1617,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalised toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../time_norm</coordinate3>
@@ -1639,7 +1639,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1654,7 +1654,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1669,7 +1669,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1684,7 +1684,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1699,7 +1699,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1714,7 +1714,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1729,7 +1729,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1744,7 +1744,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1759,7 +1759,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1774,7 +1774,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1789,7 +1789,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1804,7 +1804,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1826,7 +1826,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1842,7 +1842,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1858,7 +1858,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1874,7 +1874,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1890,7 +1890,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1906,7 +1906,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1922,7 +1922,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1938,7 +1938,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1954,7 +1954,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1970,7 +1970,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -1986,7 +1986,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2002,7 +2002,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2025,7 +2025,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2042,7 +2042,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2059,7 +2059,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2076,7 +2076,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2093,7 +2093,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2110,7 +2110,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2127,7 +2127,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2144,7 +2144,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2161,7 +2161,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2178,7 +2178,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2195,7 +2195,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2212,7 +2212,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/species</coordinate1>
 						<coordinate2>../../binormal_wavevector_norm</coordinate2>
 						<coordinate3>../../radial_wavevector_norm</coordinate3>
@@ -2236,7 +2236,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2249,7 +2249,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2262,7 +2262,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized particle flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2275,7 +2275,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2288,7 +2288,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2301,7 +2301,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the normalized energy flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2314,7 +2314,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2327,7 +2327,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2340,7 +2340,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the parallel component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2353,7 +2353,7 @@
 					<xs:documentation>Contribution of the perturbed electrostatic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2366,7 +2366,7 @@
 					<xs:documentation>Contribution of the perturbed parallel electromagnetic potential to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2379,7 +2379,7 @@
 					<xs:documentation>Contribution of the perturbed parallel magnetic field to the perpendicular component of the normalized toroidal momentum flux</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../../../../species</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2400,7 +2400,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2413,7 +2413,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2426,7 +2426,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2439,7 +2439,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2452,7 +2452,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2465,7 +2465,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../../time_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2479,7 +2479,7 @@
 						<type>constant</type>
 						<coordinate1>../../angle_pol</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2493,7 +2493,7 @@
 						<type>constant</type>
 						<coordinate1>../../angle_pol</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2507,7 +2507,7 @@
 						<type>constant</type>
 						<coordinate1>../../angle_pol</coordinate1>
 						<coordinate2>../../time_norm</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2537,7 +2537,7 @@
 					<xs:documentation>Growth rate</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2549,7 +2549,7 @@
 					<xs:documentation>Frequency</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2561,7 +2561,7 @@
 					<xs:documentation>Relative tolerance on the growth rate (convergence of the simulation)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2574,7 +2574,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2587,7 +2587,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2664,7 +2664,7 @@
 					<xs:documentation>normalized radial component of the wavevector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2676,7 +2676,7 @@
 					<xs:documentation>normalized binormal component of the wavevector</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2705,7 +2705,7 @@
 						<type>constant</type>
 						<coordinate1>../../species</coordinate1>
 						<coordinate2>../../species</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2739,7 +2739,7 @@
 					<xs:documentation>Array of normalized binormal wavevectors</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2752,7 +2752,7 @@
 					<xs:documentation>Array of normalized radial wavevectors</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2766,7 +2766,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2779,7 +2779,7 @@
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2791,7 +2791,7 @@
 					<xs:documentation>normalized time interval used to average fluxes in non-linear runs</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...2</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/hard_x_rays/dd_hard_x_rays.xsd
+++ b/schemas/hard_x_rays/dd_hard_x_rays.xsd
@@ -38,7 +38,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate grid</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -53,7 +53,7 @@
 						<type>dynamic</type>
 						<coordinate1>../rho_tor_norm</coordinate1>
 						<coordinate2>../time</coordinate2>
-						<units>(photons).m^-3.str^-1.s^-1</units>
+						<units>m^-3.sr^-1.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -65,7 +65,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate position at which the emissivity peaks</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -78,7 +78,7 @@
 					<xs:documentation>Internal (towards magnetic axis) half width of the emissivity peak (in normalized toroidal flux)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -91,7 +91,7 @@
 					<xs:documentation>External (towards separatrix) half width of the emissivity peak (in normalized toroidal flux)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -169,7 +169,7 @@
 					<xs:documentation>Etendue (geometric extent) of the channel's optical system</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>m^2.str</units>
+						<units>m^2.sr</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -209,7 +209,7 @@
 					<xs:appinfo>
 						<coordinate1>../energy_band</coordinate1>
 						<coordinate2>time</coordinate2>
-						<units>(photons).s^-1.m^-2.sr^-1</units>
+						<units>s^-1.m^-2.sr^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/ic_antennas/dd_ic_antennas.xsd
+++ b/schemas/ic_antennas/dd_ic_antennas.xsd
@@ -229,7 +229,7 @@
 				<xs:annotation>
 					<xs:documentation>Coupling resistance</xs:documentation>
 					<xs:appinfo>
-						<units>Ohm</units>
+						<units>ohm</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/interferometer/dd_interferometer.xsd
+++ b/schemas/interferometer/dd_interferometer.xsd
@@ -211,7 +211,7 @@
 					<xs:annotation>
 						<xs:documentation>Total number of electrons in the plasma, estimated from the line densities measured by the various channels</xs:documentation>
 						<xs:appinfo>
-							<units>-</units>
+							<units>1</units>
 						</xs:appinfo>
 					</xs:annotation>
 				</xs:element>

--- a/schemas/iron_core/dd_iron_core.xsd
+++ b/schemas/iron_core/dd_iron_core.xsd
@@ -50,7 +50,7 @@
 					<xs:documentation>Relative permeability of the iron segment</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../b_field</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/langmuir_probes/dd_langmuir_probes.xsd
+++ b/schemas/langmuir_probes/dd_langmuir_probes.xsd
@@ -162,7 +162,7 @@
 				<xs:annotation>
 					<xs:documentation>Skew of the ion saturation current density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.32.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -171,7 +171,7 @@
 				<xs:annotation>
 					<xs:documentation>Pearson kurtosis of the ion saturation current density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.32.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -524,7 +524,7 @@
 				<xs:annotation>
 					<xs:documentation>Skew of the ion saturation current density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.32.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -533,7 +533,7 @@
 				<xs:annotation>
 					<xs:documentation>Pearson kurtosis of the ion saturation current density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.32.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -690,7 +690,7 @@
 				<xs:annotation>
 					<xs:documentation>Parallel Mach number</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/lh_antennas/dd_lh_antennas.xsd
+++ b/schemas/lh_antennas/dd_lh_antennas.xsd
@@ -27,7 +27,7 @@
 				<xs:annotation>
 					<xs:documentation>Refraction index in the toroidal direction</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
@@ -40,7 +40,7 @@
 				<xs:annotation>
 					<xs:documentation>Refraction index in the poloidal direction. The poloidal angle is defined from the reference point; the angle at a point (R,Z) is given by atan((Z-Zref)/(R-Rref)), where Rref=reference_point/r and Zref=reference_point/z</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
@@ -145,7 +145,7 @@
 				<xs:annotation>
 					<xs:documentation>Power reflection coefficient</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -238,7 +238,7 @@
 				<xs:annotation>
 					<xs:documentation>Power reflection coefficient, averaged over modules</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -254,7 +254,7 @@
 				<xs:annotation>
 					<xs:documentation>Peak parallel refractive index of the launched wave spectrum (simple estimate based on the measured phase difference)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/magnetics/dd_magnetics.xsd
+++ b/schemas/magnetics/dd_magnetics.xsd
@@ -495,7 +495,7 @@
 					<xs:documentation>Shunt resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/mhd/dd_mhd.xsd
+++ b/schemas/mhd/dd_mhd.xsd
@@ -53,7 +53,7 @@
 					<xs:documentation>Effective charge, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/mhd_linear/dd_mhd_linear.xsd
+++ b/schemas/mhd_linear/dd_mhd_linear.xsd
@@ -474,7 +474,7 @@
 				<xs:annotation>
 					<xs:documentation>Pertubed velocity for given toroidal mode number</xs:documentation>
 					<xs:appinfo>
-						<units>m/s</units>
+						<units>m.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -575,7 +575,7 @@
 					<xs:documentation>Dominant poloidal mode number defining the mode rational surface; for TAEs the lower of the two main m's has to be specified</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -595,7 +595,7 @@
 					<xs:documentation>Radial mode number</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/nbi/dd_nbi.xsd
+++ b/schemas/nbi/dd_nbi.xsd
@@ -95,7 +95,7 @@
 					<xs:documentation>Fraction of power of a unit injected by each beamlet</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../positions/r</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -115,7 +115,7 @@
 					<xs:documentation>Fraction of injected particles in the component</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -364,7 +364,7 @@
 					<xs:appinfo>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>time</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -374,7 +374,7 @@
 					<xs:appinfo>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>time</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
+++ b/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
@@ -162,7 +162,7 @@
 					<xs:documentation>Grouped neutron flux in the detector from one neutron energy bin emitted by the current plasma voxel towards the detector</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>m^-2.neutron^-1</units>
+						<units>m^-2</units>
 						<coordinate1>../../field_of_view/emission_grid/r</coordinate1>
 						<coordinate2>../../field_of_view/emission_grid/z</coordinate2>
 						<coordinate3>../../field_of_view/emission_grid/phi</coordinate3>
@@ -203,7 +203,7 @@
 					<xs:documentation>Number of events occurring in the detector from one neutron energy bin emitted by the current plasma voxel towards the detector</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>events.neutron^-1</units>
+						<units>1</units>
 						<coordinate1>../../field_of_view/emission_grid/r</coordinate1>
 						<coordinate2>../../field_of_view/emission_grid/z</coordinate2>
 						<coordinate3>../../field_of_view/emission_grid/phi</coordinate3>
@@ -467,7 +467,7 @@
 				<xs:annotation>
 					<xs:documentation>Detected counts per second as a function of time</xs:documentation>
 					<xs:appinfo>
-						<units>counts.s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -476,7 +476,7 @@
 					<xs:documentation>Maximum count limit under which the detector response is linear</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>counts.s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -488,7 +488,7 @@
 					<xs:documentation>Minimum count limit above which the detector response is linear</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>counts.s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -500,7 +500,7 @@
 					<xs:documentation>Detected counts per second per energy channel as a function of time (in case of spectroscopic measurement mode)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../energy_band</coordinate1>
-						<units>counts.s^-1</units>
+						<units>s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/ntms/dd_ntms.xsd
+++ b/schemas/ntms/dd_ntms.xsd
@@ -102,7 +102,7 @@
 					<xs:documentation>Time derivative of the full width of the mode</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>m/s</units>
+						<units>m.s^-1</units>
 						<coordinate1>../time_detailed</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -128,7 +128,7 @@
 					<xs:documentation>Time derivative of the phase of the mode</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>rad/s</units>
+						<units>rad.s^-1</units>
 						<coordinate1>../time_detailed</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -233,7 +233,7 @@
 					<xs:documentation>Normalized flux coordinate on which the mode is centred</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../time_detailed</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -434,7 +434,7 @@
 					<xs:documentation>Time derivative of the full width of the mode</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>m/s</units>
+						<units>m.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -458,7 +458,7 @@
 					<xs:documentation>Time derivative of the phase of the mode</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>rad/s</units>
+						<units>rad.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -558,7 +558,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized flux coordinate on which the mode is centred</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/operational_instrumentation/dd_operational_instrumentation.xsd
+++ b/schemas/operational_instrumentation/dd_operational_instrumentation.xsd
@@ -133,7 +133,7 @@
 				<xs:annotation>
 					<xs:documentation>Strain measured by a strain gauge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -141,7 +141,7 @@
 				<xs:annotation>
 					<xs:documentation>Strain measured by a rosette strain gauge. The first dimension lists the components of the strain tensor : Sx1x1, Sx1x2, Sx2x2, where x1 is the main direction and x2 is the second direction of measurement. </xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...3</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/pellets/dd_pellets.xsd
+++ b/schemas/pellets/dd_pellets.xsd
@@ -40,7 +40,7 @@
 					<xs:documentation>Number of molecules of the propellant gas injected in the vacuum vessel when launching the pellet</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -83,7 +83,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -95,7 +95,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -125,7 +125,7 @@
 					<xs:documentation>Material density of the species in the pellet</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>atoms.m^-3</units>
+						<units>m^-3</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -137,7 +137,7 @@
 					<xs:documentation>Atomic fraction of the species in the pellet</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -180,7 +180,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal coordinate along the pellet path </xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../distance</coordinate1>
 					</xs:appinfo>
@@ -258,7 +258,7 @@
 				<xs:annotation>
 					<xs:documentation>Number of ablated particles (electrons) along the pellet path </xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../distance</coordinate1>
 					</xs:appinfo>
@@ -271,7 +271,7 @@
 				<xs:annotation>
 					<xs:documentation>Difference to due ExB drifts between the ablation and the final deposition locations, in terms of the normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../distance</coordinate1>
 					</xs:appinfo>

--- a/schemas/pf_active/dd_pf_active.xsd
+++ b/schemas/pf_active/dd_pf_active.xsd
@@ -46,7 +46,7 @@
 					<xs:documentation>Power supply internal resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -311,7 +311,7 @@
 					<xs:documentation>Coil resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -322,7 +322,7 @@
 				<xs:annotation>
 					<xs:documentation>Additional resistance due to e.g. dynamically switchable resistors. The coil effective resistance is obtained by adding this dynamic quantity to the static resistance of the coil. </xs:documentation>
 					<xs:appinfo>
-						<units>Ohm</units>
+						<units>ohm</units>
 						<introduced_after_version>3.36.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -464,7 +464,7 @@
 						<type>static</type>
 						<coordinate1>../limit_max</coordinate1>
 						<coordinate2>1...N</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/pf_passive/dd_pf_passive.xsd
+++ b/schemas/pf_passive/dd_pf_passive.xsd
@@ -35,7 +35,7 @@
 					<xs:documentation>Passive loop resistance</xs:documentation>
 					<xs:appinfo>
 						<Type>static</Type>
-						<Units>Ohm</Units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -47,7 +47,7 @@
 					<xs:documentation>Passive loop resistivity</xs:documentation>
 					<xs:appinfo>
 						<Type>static</Type>
-						<Units>Ohm.m</Units>
+						<units>ohm.m</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/plasma_initiation/dd_plasma_initiation.xsd
+++ b/schemas/plasma_initiation/dd_plasma_initiation.xsd
@@ -153,7 +153,7 @@
 					<xs:documentation>Fraction of open field lines : ratio open fields lines / (open+closed field lines)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -204,7 +204,7 @@
 				<xs:annotation>
 					<xs:documentation>Coulomb logarithm</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/plasma_profiles/dd_plasma_profiles.xsd
+++ b/schemas/plasma_profiles/dd_plasma_profiles.xsd
@@ -337,7 +337,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -350,7 +350,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -363,7 +363,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -376,7 +376,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -401,7 +401,7 @@
 					<xs:documentation>Volume average plasma effective charge, estimated from the flux consumption in the ohmic phase</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -414,7 +414,7 @@
 					<xs:documentation>Electron temperature peaking factor, defined as the Te value at the magnetic axis divided by the volume averaged Te (average over the plasma volume up to the LCFS)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -427,7 +427,7 @@
 					<xs:documentation>Ion temperature (averaged over ion species and states) peaking factor, defined as the Ti value at the magnetic axis divided by the volume averaged Ti (average over the plasma volume up to the LCFS)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -454,7 +454,7 @@
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -520,10 +520,10 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values</xs:documentation>
+					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -592,7 +592,7 @@
 					<xs:documentation>Normalised toroidal flux coordinate of each measurement (local value for a local measurement, minimum value reached by the line of sight for a line measurement)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -605,7 +605,7 @@
 					<xs:documentation>Normalised poloidal flux coordinate of each measurement (local value for a local measurement, minimum value reached by the line of sight for a line measurement)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -618,7 +618,7 @@
 					<xs:documentation>Weight given to each measured value</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -628,10 +628,10 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -644,7 +644,7 @@
 					<xs:documentation>Squared error normalized by the weighted standard deviation considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -677,7 +677,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -689,7 +689,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -701,7 +701,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the charge state bundle, volume averaged over the plasma radius (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -713,7 +713,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the charge state bundle, volume averaged over the plasma radius (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -726,7 +726,7 @@
 					<xs:documentation>Average charge profile of the charge state bundle (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -739,7 +739,7 @@
 					<xs:documentation>Average square charge profile of the charge state bundle (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -785,7 +785,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -961,7 +961,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -995,7 +995,7 @@
 					<xs:documentation>Average charge of the ion species (sum of states charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1008,7 +1008,7 @@
 					<xs:documentation>Average square charge of the ion species (sum of states square charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1234,7 +1234,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1685,7 +1685,7 @@
 					<xs:documentation>Collisionality normalised to the bounce frequency</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1755,7 +1755,7 @@
 					<xs:documentation>Ratio of total ion density (sum over species and charge states) over electron density. (thermal+non-thermal)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1795,7 +1795,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1806,7 +1806,7 @@
 				<xs:annotation>
 					<xs:documentation>Information on the fit used to obtain the zeff profile</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1867,7 +1867,7 @@
 					<xs:documentation>Total parallel current density = average(jtot.B) / B0, where B0 = plasma_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1893,7 +1893,7 @@
 					<xs:documentation>Total toroidal current density = average(j_phi/R) / average(1/R)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1906,7 +1906,7 @@
 					<xs:documentation>Ohmic parallel current density = average(J_Ohmic.B) / B0, where B0 = plasma_profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1994,7 +1994,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>plasma_profiles.profiles_1d{i}.q</cocos_leaf_name_aos_indices>
@@ -2009,7 +2009,7 @@
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2114,7 +2114,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2126,7 +2126,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2138,7 +2138,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the charge state bundle, volume averaged over the plasma radius (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2150,7 +2150,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the charge state bundle, volume averaged over the plasma radius (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2196,7 +2196,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2361,7 +2361,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2591,7 +2591,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/dim1</coordinate1>
 						<coordinate2>../grid/dim2</coordinate2>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2634,7 +2634,7 @@
 						<coordinate1>../grid/dim1</coordinate1>
 						<coordinate2>../grid/dim2</coordinate2>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2739,7 +2739,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2873,7 +2873,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2885,7 +2885,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2897,7 +2897,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the state bundle (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2906,7 +2906,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the state bundle (equal to z_min if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2915,7 +2915,7 @@
 				<xs:annotation>
 					<xs:documentation>Cumulative and average ionisation potential to reach a given bundle. Defined as sum (x_z* (sum of Epot from z'=0 to z-1)), where Epot is the ionisation potential of ion Xz_+, and x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2946,7 +2946,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3212,7 +3212,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -3361,7 +3361,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -3394,7 +3394,7 @@
 				<xs:annotation>
 					<xs:documentation>Particle content = total number of particles for this ion species in the volume of the grid subset, for various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3563,7 +3563,7 @@
 					<xs:documentation>Ratio of total ion density (sum over ion species) over electron density. (thermal+non-thermal), given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3581,7 +3581,7 @@
 					<xs:documentation>Effective charge, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/plasma_sources/dd_plasma_sources.xsd
+++ b/schemas/plasma_sources/dd_plasma_sources.xsd
@@ -258,7 +258,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -495,7 +495,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -507,7 +507,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -533,7 +533,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -647,7 +647,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1086,7 +1086,7 @@
 				<xs:annotation>
 					<xs:documentation>Total ion particle source (summed over ion  species)</xs:documentation>
 					<xs:appinfo>
-						<units>(ions).s^-1</units>
+						<units>s^-1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/plasma_transport/dd_plasma_transport.xsd
+++ b/schemas/plasma_transport/dd_plasma_transport.xsd
@@ -517,7 +517,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -529,7 +529,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -552,7 +552,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -619,7 +619,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -679,7 +679,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -957,7 +957,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1060,7 +1060,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1163,7 +1163,7 @@
 					<xs:documentation>Flux limiter coefficient, on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1249,7 +1249,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1310,7 +1310,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1322,7 +1322,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1345,7 +1345,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1527,7 +1527,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1610,7 +1610,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1841,7 +1841,7 @@
 					<xs:documentation>Multiplier applied to the particule flux when adding its contribution in the expression of the heat flux : can be 0, 3/2 or 5/2</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/polarimeter/dd_polarimeter.xsd
+++ b/schemas/polarimeter/dd_polarimeter.xsd
@@ -152,7 +152,7 @@
 				<xs:annotation>
 					<xs:documentation>Ellipticity</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/pulse_schedule/dd_pulse_schedule.xsd
+++ b/schemas/pulse_schedule/dd_pulse_schedule.xsd
@@ -760,7 +760,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal flux coordinate at which the main deposition should occur</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -829,7 +829,7 @@
 				<xs:annotation>
 					<xs:documentation>Main parallel refractive index of the injected wave power spectrum</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1129,7 +1129,7 @@
 					<xs:documentation>Ion charge</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1266,7 +1266,7 @@
 				<xs:annotation>
 					<xs:documentation>Line averaged effective charge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1290,7 +1290,7 @@
 				<xs:annotation>
 					<xs:documentation>Average ratio of tritium over deuterium density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1298,7 +1298,7 @@
 				<xs:annotation>
 					<xs:documentation>Average ratio of hydrogen over deuterium density</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1369,7 +1369,7 @@
 				<xs:annotation>
 					<xs:documentation>Internal inductance</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1377,7 +1377,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal beta, defined as 100 * beta_tor * a[m] * B0 [T] / ip [MA]</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>structure_renamed</change_nbc_description>
 						<change_nbc_previous_name>beta_normal</change_nbc_previous_name>
@@ -1501,7 +1501,7 @@
 				<xs:annotation>
 					<xs:documentation>Additional resistance due to e.g. dynamically switchable resistors</xs:documentation>
 					<xs:appinfo>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1583,7 +1583,7 @@
 				<xs:annotation>
 					<xs:documentation>Elongation of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1592,7 +1592,7 @@
 				<xs:annotation>
 					<xs:documentation>Elongation (upper half w.r.t. geometric axis) of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1601,7 +1601,7 @@
 				<xs:annotation>
 					<xs:documentation>Elongation (lower half w.r.t. geometric axis) of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1610,7 +1610,7 @@
 				<xs:annotation>
 					<xs:documentation>Triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1619,7 +1619,7 @@
 				<xs:annotation>
 					<xs:documentation>Upper triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1628,7 +1628,7 @@
 				<xs:annotation>
 					<xs:documentation>Lower triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1637,7 +1637,7 @@
 				<xs:annotation>
 					<xs:documentation>Inner triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -1647,7 +1647,7 @@
 				<xs:annotation>
 					<xs:documentation>Outer triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -1657,7 +1657,7 @@
 				<xs:annotation>
 					<xs:documentation>Minor triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 						<url>equilibrium/DefinitionEqBoundary.svg</url>
 					</xs:appinfo>
@@ -1667,7 +1667,7 @@
 				<xs:annotation>
 					<xs:documentation>Upper outer squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1676,7 +1676,7 @@
 				<xs:annotation>
 					<xs:documentation>Upper inner squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1685,7 +1685,7 @@
 				<xs:annotation>
 					<xs:documentation>Lower outer squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1694,7 +1694,7 @@
 				<xs:annotation>
 					<xs:documentation>Lower inner squareness of the plasma boundary (definition from T. Luce, Plasma Phys. Control. Fusion 55 (2013) 095009)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<introduced_after_version>3.38.1</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/radiation/dd_radiation.xsd
+++ b/schemas/radiation/dd_radiation.xsd
@@ -27,7 +27,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -153,7 +153,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -165,7 +165,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -191,7 +191,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -250,7 +250,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -388,7 +388,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -548,7 +548,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -560,7 +560,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -586,7 +586,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -662,7 +662,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/reflectometer_fluctuation/dd_reflectometer_fluctuation.xsd
+++ b/schemas/reflectometer_fluctuation/dd_reflectometer_fluctuation.xsd
@@ -102,7 +102,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -115,7 +115,7 @@
 					<xs:documentation>Normalized poloidal flux coordinate = sqrt((psi(rho)-psi(magnetic_axis)) / (psi(LCFS)-psi(magnetic_axis)))</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -208,7 +208,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../dn_e_over_n_e</coordinate1_same_as>
 						<coordinate2>../../time</coordinate2>
@@ -223,7 +223,7 @@
 					<xs:documentation>Normalized poloidal flux coordinate = sqrt((psi(rho)-psi(magnetic_axis)) / (psi(LCFS)-psi(magnetic_axis)))</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../dn_e_over_n_e</coordinate1_same_as>
 						<coordinate2>../../time</coordinate2>
@@ -260,7 +260,7 @@
 					<xs:documentation>Relative amplitude of the density fluctuations post-processed for swept and fixed frequency (profile/one point)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate2>../time</coordinate2>
 					</xs:appinfo>

--- a/schemas/runaway_electrons/dd_runaway_electrons.xsd
+++ b/schemas/runaway_electrons/dd_runaway_electrons.xsd
@@ -125,7 +125,7 @@
 					<xs:documentation>Average pitch angle of the runaways distribution function (v_parallel/|v|)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -361,7 +361,7 @@
 					<xs:documentation>Average pitch angle of the runaways distribution function (v_parallel/|v|), given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -522,7 +522,7 @@
 					<xs:documentation>Average pitch angle of the runaways distribution function (v_parallel/|v|)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/sawteeth/dd_sawteeth.xsd
+++ b/schemas/sawteeth/dd_sawteeth.xsd
@@ -71,7 +71,7 @@
 					<xs:documentation>Ratio of total ion density (sum over species and charge states) over electron density. (thermal+non-thermal)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -85,7 +85,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
 						<type>dynamic</type>
-						<units>kg.m/s</units>
+						<units>kg.m.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -98,7 +98,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -227,7 +227,7 @@
 					<xs:documentation>Total parallel current density = average(jtot.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -240,7 +240,7 @@
 					<xs:documentation>Total toroidal current density = average(J_Tor/R) / average(1/R)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -253,7 +253,7 @@
 					<xs:documentation>Ohmic parallel current density = average(J_Ohmic.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -266,7 +266,7 @@
 					<xs:documentation>Non-inductive (includes bootstrap) parallel current density = average(jni.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -279,7 +279,7 @@
 					<xs:documentation>Bootstrap current density = average(J_Bootstrap.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -319,7 +319,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -331,7 +331,7 @@
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -399,7 +399,7 @@
 					<xs:documentation>Magnetic shear at surface q = 1, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -412,7 +412,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate at surface q = 1</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -425,7 +425,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate at inversion radius</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -438,7 +438,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate at mixing radius</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/spectrometer_mass/dd_spectrometer_mass.xsd
+++ b/schemas/spectrometer_mass/dd_spectrometer_mass.xsd
@@ -14,7 +14,7 @@
 					<xs:documentation>Array of atomic masses</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -56,7 +56,7 @@
 					<xs:documentation>Atomic mass measured by this channel</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/spectrometer_uv/dd_spectrometer_uv.xsd
+++ b/schemas/spectrometer_uv/dd_spectrometer_uv.xsd
@@ -346,7 +346,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated spectral radiance (radiance per unit wavelength)</xs:documentation>
 					<xs:appinfo>
-						<units>(photons).m^-2.s^-1.sr^-1.m^-1</units>
+						<units>m^-2.s^-1.sr^-1.m^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -356,7 +356,7 @@
 				<xs:annotation>
 					<xs:documentation>Intensity spectrum (not calibrated), i.e. number of photoelectrons detected by unit time by a wavelength pixel of the channel, taking into account electronic gain compensation and channels relative calibration</xs:documentation>
 					<xs:appinfo>
-						<units>(counts) s^-1</units>
+						<units>s^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>

--- a/schemas/spectrometer_visible/dd_spectrometer_visible.xsd
+++ b/schemas/spectrometer_visible/dd_spectrometer_visible.xsd
@@ -280,7 +280,7 @@
 					<xs:documentation>Values of the light collection efficiencies</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../positions/r</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -317,7 +317,7 @@
 					<xs:documentation>Ellipticity</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -386,7 +386,7 @@
 					<xs:documentation>Ratio of the density of neutrals of this isotope over the summed neutral densities of all other isotopes described in the ../isotope array</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -399,7 +399,7 @@
 					<xs:documentation>Fraction of cold neutrals for this isotope (n_cold_neutrals/(n_cold_neutrals+n_hot_neutrals))</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -412,7 +412,7 @@
 					<xs:documentation>Fraction of hot neutrals for this isotope (n_hot_neutrals/(n_cold_neutrals+n_hot_neutrals))</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -880,7 +880,7 @@
 				<xs:annotation>
 					<xs:documentation>Calibrated spectral radiance (radiance per unit wavelength)</xs:documentation>
 					<xs:appinfo>
-						<units>(photons).m^-2.s^-1.sr^-1.m^-1</units>
+						<units>m^-2.s^-1.sr^-1.m^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -890,7 +890,7 @@
 				<xs:annotation>
 					<xs:documentation>Intensity spectrum (not calibrated), i.e. number of photoelectrons detected by unit time by a wavelength pixel of the channel, taking into account electronic gain compensation and channels relative calibration</xs:documentation>
 					<xs:appinfo>
-						<units>(counts) s^-1</units>
+						<units>s^-1</units>
 						<coordinate1>../wavelengths</coordinate1>
 						<coordinate2>time</coordinate2>
 					</xs:appinfo>
@@ -1023,7 +1023,7 @@
 					<xs:documentation>Etendue (geometric extent) of the channel's optical system</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>m^2.str</units>
+						<units>m^2.sr</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/spectrometer_x_ray_crystal/dd_spectrometer_x_ray_crystal.xsd
+++ b/schemas/spectrometer_x_ray_crystal/dd_spectrometer_x_ray_crystal.xsd
@@ -523,7 +523,7 @@
 				<xs:annotation>
 					<xs:documentation>Number of counts detected on each pixel of the frame during one exposure time</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../wavelength_frames</coordinate1_same_as>
@@ -539,7 +539,7 @@
 				<xs:annotation>
 					<xs:documentation>Number of counts detected on each pixel/bin of the binned frame during one exposure time</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../wavelength_frames</coordinate1_same_as>
@@ -576,7 +576,7 @@
 				<xs:annotation>
 					<xs:documentation>Shortest distance in rho_tor_norm between lines of sight and magnetic axis, signed with following convention : positive (resp. negative) means the point of shortest distance is above (resp. below) the magnetic axis</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../lines_of_sight_second_point/r</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -762,7 +762,7 @@
 					<xs:documentation>Probability of detection of a photon impacting the detector as a function of its energy </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../energies</coordinate1>
 						<introduced_after_version>3.34.0</introduced_after_version>
 					</xs:appinfo>

--- a/schemas/spi/dd_spi.xsd
+++ b/schemas/spi/dd_spi.xsd
@@ -11,7 +11,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -23,7 +23,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -50,7 +50,7 @@
 					<xs:documentation>Density of the species</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>atoms.m^-3</units>
+						<units>m^-3</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -68,7 +68,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -80,7 +80,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -107,7 +107,7 @@
 					<xs:documentation>Atomic fraction of the species</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -259,7 +259,7 @@
 				<xs:annotation>
 					<xs:documentation>Total number of atoms of desublimated gas</xs:documentation>
 					<xs:appinfo>
-						<units>atoms</units>
+						<units>1</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -278,7 +278,7 @@
 				<xs:annotation>
 					<xs:documentation>Flow rate of the gas at the injector exit</xs:documentation>
 					<xs:appinfo>
-						<units>atoms.s^-1</units>
+						<units>s^-1</units>
 						<type>dynamic</type>
 						<coordinate1>/time</coordinate1>
 					</xs:appinfo>
@@ -299,7 +299,7 @@
 				<xs:annotation>
 					<xs:documentation>Total number of atoms of the gas</xs:documentation>
 					<xs:appinfo>
-						<units>atoms</units>
+						<units>1</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/summary/dd_summary.xsd
+++ b/schemas/summary/dd_summary.xsd
@@ -1121,7 +1121,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1129,7 +1129,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1156,7 +1156,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../../../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1228,7 +1228,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../../../../time</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1317,7 +1317,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective charge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1350,7 +1350,7 @@
 				<xs:annotation>
 					<xs:documentation>Safety factor (only positive when toroidal current and magnetic field are in same direction)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>IDSPATH.q.value</cocos_leaf_name_aos_indices>
@@ -1361,7 +1361,7 @@
 				<xs:annotation>
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1446,7 +1446,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective charge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1454,7 +1454,7 @@
 				<xs:annotation>
 					<xs:documentation>Magnetic flux expansion as defined by Stangeby : ratio between the poloidal field at the midplane separatrix and the poloidal field at the strike-point see formula attached, where u means upstream (midplane separatrix) and t means at divertor target (downstream).</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<url>divertors/flux_expansion.png</url>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1478,7 +1478,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective helical ripple for 1/nu neoclassical regime (see [Beidler, C. D., and W. N. G. Hitchon, 1994, Plasma Phys. Control. Fusion 35, 317])</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1486,7 +1486,7 @@
 				<xs:annotation>
 					<xs:documentation>Plateau factor, as defined in equation (25) of reference [Stroth U. et al 1998 Plasma Phys. Control. Fusion 40 1551]</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1494,7 +1494,7 @@
 				<xs:annotation>
 					<xs:documentation>Rotational transform (1/q)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1554,7 +1554,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective charge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1587,7 +1587,7 @@
 				<xs:annotation>
 					<xs:documentation>Safety factor</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>IDSPATH.q.value</cocos_leaf_name_aos_indices>
@@ -1598,7 +1598,7 @@
 				<xs:annotation>
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1624,7 +1624,7 @@
 				<xs:annotation>
 					<xs:documentation>Critical normalized pressure gradient determined with self-consistent runs with an MHD stability code. Details of the method for scanning parameters in the series of runs must be described in the 'source' node</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1632,7 +1632,7 @@
 				<xs:annotation>
 					<xs:documentation>Ratio of alpha_critical over alpha_experimental</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1655,7 +1655,7 @@
 				<xs:annotation>
 					<xs:documentation>Experimental normalized pressure gradient reconstructed by an MHD stability code (with assumptions on the ion pressure). See definition in [Miller PoP 5 (1998),973,Eq. 42]</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1685,7 +1685,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal full width in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1693,7 +1693,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal position in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1728,7 +1728,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal full width in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1736,7 +1736,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal position in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1759,7 +1759,7 @@
 				<xs:annotation>
 					<xs:documentation>Position (in terms of normalized poloidal flux) of the maximum gradient of the parent quantity in the pedestal</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1784,7 +1784,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal full width in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1792,7 +1792,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal position in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1832,7 +1832,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal full width in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1840,7 +1840,7 @@
 				<xs:annotation>
 					<xs:documentation>Pedestal position in normalized poloidal flux</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1863,7 +1863,7 @@
 				<xs:annotation>
 					<xs:documentation>Position (in terms of normalized poloidal flux) of the maximum gradient of the parent quantity in the pedestal</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1926,7 +1926,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pressure pedestal top for electrons using the flux surface average magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1934,7 +1934,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pressure pedestal top for electrons using the low field side magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1942,7 +1942,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pressure pedestal top for electrons using the high field side magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1950,7 +1950,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized collisionality at pressure pedestal top for electrons</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1958,7 +1958,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the low field side magnetic field (important for spherical tokamaks)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1966,7 +1966,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the high field side magnetic field (important for spherical tokamaks)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1974,7 +1974,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the magnetic field on the magnetic axis (definition used in most tokamak literature)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2044,7 +2044,7 @@
 				<xs:annotation>
 					<xs:documentation>Coulomb factor log(lambda) at the position of the pressure pedestal top (as determined by the fit)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2120,7 +2120,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum value in the pedestal of the alpha parameter for electron pressure (see [Miller PoP 5 (1998),973,Eq. 42])</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2128,7 +2128,7 @@
 				<xs:annotation>
 					<xs:documentation>Position in normalized poloidal flux of the maximum value in the pedestal of the alpha parameter for electron pressure (see [Miller PoP 5 (1998),973,Eq. 42])</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2136,7 +2136,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pressure pedestal top for electrons using the flux surface average magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2144,7 +2144,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pedestal top for electrons using the low field side magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2152,7 +2152,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta at pressure pedestal top for electrons using the high field side magnetic poloidal field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2160,7 +2160,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized collisionality at pressure pedestal top for electrons</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2168,7 +2168,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the low field side magnetic field (important for spherical tokamaks)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2176,7 +2176,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the high field side magnetic field (important for spherical tokamaks)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2184,7 +2184,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized Larmor radius at pressure pedestal top for electrons using the magnetic field on the magnetic axis (definition used in most tokamak litterature)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2254,7 +2254,7 @@
 				<xs:annotation>
 					<xs:documentation>Coulomb factor log(lambda) at the position of the pressure pedestal top (as determined by the fit)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2486,7 +2486,7 @@
 				<xs:annotation>
 					<xs:documentation>Time derivative of the electron density</xs:documentation>
 					<xs:appinfo>
-						<units>m^-3.s-1</units>
+						<units>m^-3.s^-1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2510,7 +2510,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective charge</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2518,7 +2518,7 @@
 				<xs:annotation>
 					<xs:documentation>Effective mass of the hydrogenic species (MH. nH+MD.nD+MT.nT)/(nH+nD+nT)  </xs:documentation>
 					<xs:appinfo>
-						<units>amu</units>
+						<units>u</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2526,7 +2526,7 @@
 				<xs:annotation>
 					<xs:documentation>Fraction of hydrogen density among the hydrogenic species (nH/(nH+nD+nT))</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2621,7 +2621,7 @@
 				<xs:annotation>
 					<xs:documentation>Elongation of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2629,7 +2629,7 @@
 				<xs:annotation>
 					<xs:documentation>Upper triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2637,7 +2637,7 @@
 				<xs:annotation>
 					<xs:documentation>Lower triangularity of the plasma boundary</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2803,7 +2803,7 @@
 				<xs:annotation>
 					<xs:documentation>Internal inductance. The li_3 definition is used, i.e. li_3 = 2/R0/mu0^2/Ip^2 * int(Bp^2 dV).</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>structure_renamed</change_nbc_description>
 						<change_nbc_previous_name>li</change_nbc_previous_name>
@@ -2814,7 +2814,7 @@
 				<xs:annotation>
 					<xs:documentation>Internal inductance as determined by an equilibrium reconstruction code. Use this only when the li node above is used for another estimation method and there is a need to store a second value of li (determined by an equilibrium reconstruction code). The li_3 definition is used, i.e. li_3 = 2/R0/mu0^2/Ip^2 * int(Bp^2 dV).</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>structure_renamed</change_nbc_description>
 						<change_nbc_previous_name>li_mhd</change_nbc_previous_name>
@@ -2825,7 +2825,7 @@
 				<xs:annotation>
 					<xs:documentation>Toroidal beta, defined as the volume-averaged total perpendicular pressure divided by (B0^2/(2*mu0)), i.e. beta_toroidal = 2 mu0 int(p dV) / V / B0^2</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2833,7 +2833,7 @@
 				<xs:annotation>
 					<xs:documentation>Toroidal beta, using the pressure determined by an equilibrium reconstruction code</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2841,7 +2841,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal beta, defined as 100 * beta_tor * a[m] * B0 [T] / ip [MA] </xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2849,7 +2849,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal beta, using the pressure determined by an equilibrium reconstruction code</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2857,7 +2857,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal beta from thermal pressure only, defined as 100 * beta_tor_thermal * a[m] * B0 [T] / ip [MA] </xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2865,7 +2865,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta. Defined as betap = 4 int(p dV) / [R_0 * mu_0 * Ip^2]</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -2873,7 +2873,7 @@
 				<xs:annotation>
 					<xs:documentation>Poloidal beta estimated from the pressure determined by an equilibrium reconstruction code. Defined as betap = 4 int(p dV) / [R_0 * mu_0 * Ip^2]</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3001,7 +3001,7 @@
 				<xs:annotation>
 					<xs:documentation>Fusion gain : ratio of the power provided by fusion reactions to the auxiliary power needed to heat the plasma. Often noted as Q in the litterature.</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3009,7 +3009,7 @@
 				<xs:annotation>
 					<xs:documentation>Energy confinement time enhancement factor over the IPB98(y,2) scaling</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3049,7 +3049,7 @@
 				<xs:annotation>
 					<xs:documentation>Ratio of Helium confinement time to fuel confinement time</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3065,7 +3065,7 @@
 				<xs:annotation>
 					<xs:documentation>q at the 95% poloidal flux surface (only positive when toroidal current and magnetic field are in same direction)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>summary.global_quantities.q_95.value</cocos_leaf_name_aos_indices>
@@ -3148,7 +3148,7 @@
 				<xs:annotation>
 					<xs:documentation>Greenwald fraction =line_average/n_e/value divided by (global_quantities/ip/value *1e6 * pi * minor_radius^2)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3311,7 +3311,7 @@
 				<xs:annotation>
 					<xs:documentation>Number of runaway electrons</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3400,7 +3400,7 @@
 				<xs:annotation>
 					<xs:documentation>Fractions of beam current distributed among the different energies, the first index corresponds to the fast neutrals energy (1:full, 2: half, 3: one third)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3408,7 +3408,7 @@
 				<xs:annotation>
 					<xs:documentation>Fractions of beam power distributed among the different energies, the first index corresponds to the fast neutrals energy (1:full, 2: half, 3: one third)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3431,7 +3431,7 @@
 				<xs:annotation>
 					<xs:documentation>Position of the maximum of the ECRH power deposition, in rho_tor_norm</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3526,7 +3526,7 @@
 				<xs:annotation>
 					<xs:documentation>Position of the maximum of the LH power deposition, in rho_tor_norm</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3534,7 +3534,7 @@
 				<xs:annotation>
 					<xs:documentation>Main parallel refractive index of LH waves at launch</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3592,7 +3592,7 @@
 				<xs:annotation>
 					<xs:documentation>Position of the maximum of the ICRH power deposition, in rho_tor_norm</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3618,7 +3618,7 @@
 				<xs:annotation>
 					<xs:documentation>Average E+/E- power ratio of IC waves</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3749,7 +3749,7 @@
 				<xs:annotation>
 					<xs:documentation>Ratio of co-injected beam launched power to total NBI launched power. Is set to 1 for purely perpendicular injection</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -3804,7 +3804,7 @@
 				<xs:annotation>
 					<xs:documentation>User-defined parameter, see description of linear_custom</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3816,7 +3816,7 @@
 				<xs:annotation>
 					<xs:documentation>User-defined value, see description of linear_custom</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4074,7 +4074,7 @@
 					<xs:annotation>
 						<xs:documentation>Gas injection rates in equivalent electrons.s^-1</xs:documentation>
 						<xs:appinfo>
-							<units>electrons.s^-1</units>
+							<units>s^-1</units>
 						</xs:appinfo>
 					</xs:annotation>
 				</xs:element>
@@ -4082,7 +4082,7 @@
 					<xs:annotation>
 						<xs:documentation>Accumulated injected gas since the plasma breakdown in equivalent electrons</xs:documentation>
 						<xs:appinfo>
-							<units>electrons</units>
+							<units>1</units>
 							<introduced_after_version>3.36.0</introduced_after_version>
 						</xs:appinfo>
 					</xs:annotation>
@@ -4091,7 +4091,7 @@
 					<xs:annotation>
 						<xs:documentation>Accumulated injected gas during the prefill in equivalent electrons</xs:documentation>
 						<xs:appinfo>
-							<units>electrons</units>
+							<units>1</units>
 							<introduced_after_version>3.37.2</introduced_after_version>
 						</xs:appinfo>
 					</xs:annotation>

--- a/schemas/temporary/dd_temporary.xsd
+++ b/schemas/temporary/dd_temporary.xsd
@@ -14,7 +14,7 @@
 					<xs:documentation>Value</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -84,7 +84,7 @@
 					<xs:documentation>Value</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/tf/dd_tf.xsd
+++ b/schemas/tf/dd_tf.xsd
@@ -75,7 +75,7 @@
 					<xs:documentation>conductor resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -142,7 +142,7 @@
 					<xs:documentation>Number of total turns in a toroidal field coil. May be a fraction when describing the coil connections.</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -154,7 +154,7 @@
 					<xs:documentation>Coil resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/thomson_scattering/dd_thomson_scattering.xsd
+++ b/schemas/thomson_scattering/dd_thomson_scattering.xsd
@@ -46,7 +46,7 @@
 					<xs:appinfo>
 						<type>static</type>
 						<coordinate1>../wavelength_band</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -70,7 +70,7 @@
 					<xs:appinfo>
 						<type>static</type>
 						<coordinate1>../wavelength_band</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/transport_solver_numerics/dd_transport_solver_numerics.xsd
+++ b/schemas/transport_solver_numerics/dd_transport_solver_numerics.xsd
@@ -177,7 +177,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -189,7 +189,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -215,7 +215,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -290,7 +290,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -303,7 +303,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -314,7 +314,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -430,7 +430,7 @@
 					<xs:documentation>Value of the relative deviation</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/turbulence/dd_turbulence.xsd
+++ b/schemas/turbulence/dd_turbulence.xsd
@@ -104,7 +104,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>

--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -379,7 +379,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate of the measurement</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -831,7 +831,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -843,7 +843,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -880,7 +880,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -935,7 +935,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -976,7 +976,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -988,7 +988,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1025,7 +1025,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1064,7 +1064,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1164,7 +1164,7 @@
 					<xs:documentation>Relative fraction of this species (in molecules) in the gas mixture</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1194,7 +1194,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1245,7 +1245,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1257,7 +1257,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -1293,7 +1293,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>constant</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1305,7 +1305,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>constant</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -1341,7 +1341,7 @@
 				<xs:annotation>
 					<xs:documentation>Mass of atom</xs:documentation>
 					<xs:appinfo>
-						<units>Atomic Mass Unit</units>
+						<units>u</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1353,7 +1353,7 @@
 				<xs:annotation>
 					<xs:documentation>Nuclear charge</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 						<change_nbc_version>4.0.0</change_nbc_version>
 						<change_nbc_description>type_changed</change_nbc_description>
@@ -1497,7 +1497,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../n_e/data</coordinate1_same_as>
 						<coordinate2>../../n_e/time</coordinate2>
@@ -1513,7 +1513,7 @@
 					<xs:documentation>Normalized poloidal flux coordinate = sqrt((psi(rho)-psi(magnetic_axis)) / (psi(LCFS)-psi(magnetic_axis)))</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../n_e/data</coordinate1_same_as>
 						<coordinate2>../../n_e/time</coordinate2>
@@ -2386,7 +2386,7 @@
 					<xs:documentation>conductor resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2444,7 +2444,7 @@
 					<xs:documentation>Number of total turns in the coil. May be a fraction when describing the coil connections.</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2456,7 +2456,7 @@
 					<xs:documentation>Coil resistance</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2720,7 +2720,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2746,7 +2746,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../rho_pol_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2846,7 +2846,7 @@
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
 						<alternative_coordinate1>../rho_tor;../psi;../volume;../area;../surface;../rho_pol_norm</alternative_coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2872,7 +2872,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -2967,10 +2967,10 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values</xs:documentation>
+					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>1...N</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3039,7 +3039,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate of each measurement (local value for a local measurement, minimum value reached by the line of sight for a line measurement)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3052,7 +3052,7 @@
 					<xs:documentation>Weight given to each measured value</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3062,10 +3062,10 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>as_parent for a local measurement, as_parent.m for a line integrated measurement</units>
+						<units>mixed</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3078,7 +3078,7 @@
 					<xs:documentation>Squared error normalized by the weighted standard deviation considered in the minimization process : chi_squared = weight^2 *(reconstructed - measured)^2 / sigma^2, where sigma is the standard deviation of the measurement error</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../measured</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3111,7 +3111,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3123,7 +3123,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3135,7 +3135,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z of the charge state bundle, volume averaged over the plasma radius (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3147,7 +3147,7 @@
 				<xs:annotation>
 					<xs:documentation>Average Z square of the charge state bundle, volume averaged over the plasma radius (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3160,7 +3160,7 @@
 					<xs:documentation>Average charge profile of the charge state bundle (equal to z_min if no bundle), = sum (Z*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3173,7 +3173,7 @@
 					<xs:documentation>Average square charge profile of the charge state bundle (equal to z_min squared if no bundle), = sum (Z^2*x_z) where x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle.</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3225,7 +3225,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3401,7 +3401,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed), volume averaged over plasma radius</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -3438,7 +3438,7 @@
 					<xs:documentation>Average charge of the ion species (sum of states charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3451,7 +3451,7 @@
 					<xs:documentation>Average square charge of the ion species (sum of states square charge weighted by state density and divided by ion density)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -3680,7 +3680,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4134,7 +4134,7 @@
 					<xs:documentation>Collisionality normalized to the bounce frequency</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4204,7 +4204,7 @@
 					<xs:documentation>Ratio of total ion density (sum over species and charge states) over electron density. (thermal+non-thermal)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4247,7 +4247,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -4258,7 +4258,7 @@
 				<xs:annotation>
 					<xs:documentation>Information on the fit used to obtain the zeff profile</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -4319,7 +4319,7 @@
 					<xs:documentation>Total parallel current density = average(jtot.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4345,7 +4345,7 @@
 					<xs:documentation>Total toroidal current density = average(J_phi/R) / average(1/R)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 						<change_nbc_version>3.42.0</change_nbc_version>
 						<change_nbc_description>leaf_renamed</change_nbc_description>
@@ -4361,7 +4361,7 @@
 					<xs:documentation>Ohmic parallel current density = average(J_Ohmic.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4374,7 +4374,7 @@
 					<xs:documentation>Non-inductive (includes bootstrap) parallel current density = average(jni.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4387,7 +4387,7 @@
 					<xs:documentation>Bootstrap current density = average(J_Bootstrap.B) / B0, where B0 = Core_Profiles/Vacuum_Toroidal_Field/ B0</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>A/m^2</units>
+						<units>A.m^-2</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4449,7 +4449,7 @@
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<cocos_label_transformation>q_like</cocos_label_transformation>
 						<cocos_transformation_expression>.fact_q</cocos_transformation_expression>
 						<cocos_leaf_name_aos_indices>IDSPATH.q</cocos_leaf_name_aos_indices>
@@ -4464,7 +4464,7 @@
 					<xs:documentation>Magnetic shear, defined as rho_tor/q . dq/drho_tor</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>../grid/rho_tor_norm</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4575,7 +4575,7 @@
 					<xs:documentation>Probability of detection of a photon impacting the detector as a function of its energy </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../energies</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4632,7 +4632,7 @@
 					<xs:documentation>Probability of detection of a photon impacting the detector as a function of its wavelength </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4689,7 +4689,7 @@
 					<xs:documentation>Probability of detection of a photon impacting the detector as a function of its wavelength </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4739,7 +4739,7 @@
 						<coordinate1>../expressions</coordinate1>
 						<coordinate2>../../weights</coordinate2>
 						<coordinate3>../time_orbit</coordinate3>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4814,7 +4814,7 @@
 						<coordinate3>../n_tor</coordinate3>
 						<coordinate4>../m_pol</coordinate4>
 						<coordinate5>../bounce_harmonics</coordinate5>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -4847,7 +4847,7 @@
 					<xs:documentation>Weight of the markers, i.e. number of real particles represented by each marker. The dimension of the vector correspond to the number of markers</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -7090,7 +7090,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -7186,7 +7186,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -7262,7 +7262,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -7274,7 +7274,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -7300,7 +7300,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -7380,7 +7380,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -7782,7 +7782,7 @@
 					<xs:documentation>Normalized toroidal flux coordinate. The normalizing value for rho_tor_norm, is the toroidal flux coordinate at the equilibrium boundary (LCFS or 99.x % of the LCFS in case of a fixed boundary equilibium calculation, see time_slice/boundary/b_flux_pol_norm in the equilibrium IDS) </xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -8125,7 +8125,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -8216,7 +8216,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../time</coordinate1>
 						<utilities_aoscontext>yes</utilities_aoscontext>
@@ -9170,7 +9170,7 @@
 					<xs:documentation>Probability of absorbing a photon passing through the filter as a function of its wavelength </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -9937,7 +9937,7 @@
 					<xs:documentation>Refractive index (for metal and dielectric)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -9950,7 +9950,7 @@
 					<xs:documentation>Extinction coefficient (for metal)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -9963,7 +9963,7 @@
 					<xs:documentation>Transmission coefficient (for dielectric)</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -9976,7 +9976,7 @@
 					<xs:documentation>Roughness parameter of the material. Varies in range [0, 1]. 0 is perfectly specular, 1 is perfectly rough</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../wavelengths</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -10423,7 +10423,7 @@
 					<xs:documentation>Number of effective turns in the element for calculating the magnetic field from the coil/loop. Should be positive, unless the coil has elements going in opposite directions. </xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -10509,7 +10509,7 @@
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../bins</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -10744,7 +10744,7 @@
 					<xs:documentation>Resistance of the block element</xs:documentation>
 					<xs:appinfo>
 						<type>static</type>
-						<units>Ohm</units>
+						<units>ohm</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -11022,7 +11022,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized power flow in the direction perpendicular to the magnetic field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 					</xs:appinfo>
@@ -11035,7 +11035,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized power flow in the direction parallel to the magnetic field</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 					</xs:appinfo>
@@ -11145,7 +11145,7 @@
 					<xs:documentation>Normalised toroidal flux coordinate</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>../../length</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -11222,7 +11222,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized wave vector component in the major radius direction = k_r / norm(k)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 						<introduced_after_version>3.38.1</introduced_after_version>
@@ -11236,7 +11236,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized wave vector component in the vertical direction = k_z / norm(k)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 						<introduced_after_version>3.38.1</introduced_after_version>
@@ -11250,7 +11250,7 @@
 				<xs:annotation>
 					<xs:documentation>Normalized wave vector component in the toroidal direction = k_phi / norm(k)</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 						<change_nbc_version>3.42.0</change_nbc_version>
@@ -11266,7 +11266,7 @@
 				<xs:annotation>
 					<xs:documentation>Parallel refractive index</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 					</xs:appinfo>
@@ -11279,7 +11279,7 @@
 				<xs:annotation>
 					<xs:documentation>Perpendicular refractive index</xs:documentation>
 					<xs:appinfo>
-						<units>-</units>
+						<units>1</units>
 						<type>dynamic</type>
 						<coordinate1>../../length</coordinate1>
 					</xs:appinfo>

--- a/schemas/wall/dd_wall.xsd
+++ b/schemas/wall/dd_wall.xsd
@@ -135,7 +135,7 @@
 					<xs:documentation>Effective coefficient of physical sputtering for various neutral types (first dimension: 1: cold; 2: thermal; 3: fast), due to this incident species and for various energies (second dimension)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>../energies</coordinate2>
 						<coordinate3>/time</coordinate3>
@@ -150,7 +150,7 @@
 					<xs:documentation>Effective coefficient of chemical sputtering for various neutral types (first dimension: 1: cold; 2: thermal; 3: fast), due to this incident species</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>/time</coordinate2>
 					</xs:appinfo>
@@ -246,7 +246,7 @@
 					<xs:documentation>Wall inventory, i.e. cumulated exchange of neutral species between plasma and wall from t = 0, positive if a species has gone to the wall, for that species</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>/time</coordinate1>
 					</xs:appinfo>
 				</xs:annotation>
@@ -259,7 +259,7 @@
 					<xs:documentation>Particle recycling coefficient corresponding to the conversion into various neutral types (first dimension: 1: cold; 2: thermal; 3: fast)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>/time</coordinate2>
 					</xs:appinfo>
@@ -273,7 +273,7 @@
 					<xs:documentation>Energy recycling coefficient corresponding to the conversion into various neutral types (first dimension: 1: cold; 2: thermal; 3: fast)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>-</units>
+						<units>1</units>
 						<coordinate1>1...3</coordinate1>
 						<coordinate2>/time</coordinate2>
 					</xs:appinfo>
@@ -761,7 +761,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -902,7 +902,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -914,7 +914,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -940,7 +940,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1008,7 +1008,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1180,7 +1180,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1321,7 +1321,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1333,7 +1333,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1359,7 +1359,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1427,7 +1427,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1574,7 +1574,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1614,7 +1614,7 @@
 					<xs:documentation>Recycling coefficient for various wall components (grid subsets)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1663,7 +1663,7 @@
 					<xs:documentation>Recycling coefficient for various wall components (grid subsets)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1697,7 +1697,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1709,7 +1709,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1735,7 +1735,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1770,7 +1770,7 @@
 					<xs:documentation>Recycling coefficient for various wall components (grid subsets)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1794,7 +1794,7 @@
 					<xs:documentation>Ion charge (of the dominant ionization state; lumped ions are allowed)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1831,7 +1831,7 @@
 					<xs:documentation>Recycling coefficient for various wall components (grid subsets)</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1991,7 +1991,7 @@
 					<xs:documentation>Resistivity, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
 						<coordinate1>1...N</coordinate1>
-						<units>Ohm.m</units>
+						<units>ohm.m</units>
 						<introduced_after_version>3.39.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/waves/dd_waves.xsd
+++ b/schemas/waves/dd_waves.xsd
@@ -85,7 +85,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -97,7 +97,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -134,7 +134,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -186,7 +186,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -355,7 +355,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -367,7 +367,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -404,7 +404,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -499,7 +499,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -806,7 +806,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -818,7 +818,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -855,7 +855,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1014,7 +1014,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1762,7 +1762,7 @@
 						<coordinate2>1...N</coordinate2>
 						<coordinate1_same_as>../r</coordinate1_same_as>
 						<coordinate2_same_as>../r</coordinate2_same_as>
-						<units>-</units>
+						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -1844,7 +1844,7 @@
 				<xs:annotation>
 					<xs:documentation>Minimum Z of the charge state bundle (z_min = z_max = 0 for a neutral)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1856,7 +1856,7 @@
 				<xs:annotation>
 					<xs:documentation>Maximum Z of the charge state bundle (equal to z_min if no bundle)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -1893,7 +1893,7 @@
 				<xs:annotation>
 					<xs:documentation>Vibrational level (can be bundled)</xs:documentation>
 					<xs:appinfo>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 						<type>dynamic</type>
 					</xs:appinfo>
 				</xs:annotation>
@@ -2004,7 +2004,7 @@
 					<xs:documentation>Ion charge (of the dominant ionisation state; lumped ions are allowed).</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>Elementary Charge Unit</units>
+						<units>e</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>


### PR DESCRIPTION
This pull request fixes https://jira.iter.org/browse/IMAS-5246 (behind login wall).

## Changed units

Updated several units descriptions in the Data Dictionary to be
compliant to the UDUNITS2 convention and the [internal guidelines that no '/'
shall be used in the units descriptions](
https://imas-data-dictionary.readthedocs.io/en/latest/dm_rules_guidelines.html#:~:text=10%20May%202013-,R5.3,-Float%20and%20Complex).

Overview of changes:
- Update data model rules and guidelines documentation
- Dimensionless quantities are now represented by `1` instead of `-` (or
  non-unit `counts`, `photons`, `electrons`, `ions`, etc.)
- `u` is used in place of `Atomic Mass Unit`
- `e` is used in place of `Elementary Charge Unit`
- Fix a couple of instances where `str` was used instead of `sr` for steradians
- Use `mixed` units instead of `as_parent for a local measurement, as_parent.m
  for a line integrated measurement`
- Update some units to eliminate `/` (in accordance with data model guidelines):
  `A/m^2` -> `A.m^-2`, `T^2.m^2/Wb` -> `T^2.m^2.Wb^-1`, `m/s` -> `m.s^-1`,
  `rad/s` -> `rad.s^-1`
- `ohm` is used instead of `Ohm`
- Fix `m^-3.s-1` -> `m^-3.s^-1`

## Technical changes

Resolve all `as_parent` units during generation of `dd_data_dictionary.xml` and replace them with the actual units.
N.B. `as_parent(_level_2)` units are still present in the utilities section of the generated XML, though in all IDSs they are resolved.

This will also reflect in the generated documentation: for example [`gauge/pressure/data` in the barometry IDS](https://imas-data-dictionary.readthedocs.io/en/latest/generated/ids/barometry.html#barometry-gauge-pressure-data) now indicates `as_parent` as units. After this PR is merged, `Pa` will be shown instead.

## Documentation updates

Update the Data Model Rules and Guidelines, and the user documentation on units to reflect the changes.
