### PR TITLE
Add GitHub Actions workflow to build with `make`

### DIFF
--- a/.github/workflows/test_make.yml
+++ b/.github/workflows/test_make.yml
@@ -1,0 +1,20 @@
+name: test-make
+
+on: push
+
+jobs:
+  build:
+    name: Make
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 
+    - name: Install java and SaxonHE
+      run: |
+        sudo apt update
+        sudo apt install -y libsaxonhe-java
+    - name: Make
+      run: |
+        export CLASSPATH=/usr/share/java/Saxon-HE.jar
+        make


### PR DESCRIPTION
Enables the validation checks (see #36)

Workflow fails if any of the checks in `dd_data_dictionary_validation.txt.xsl` fails. Tested in https://github.com/maarten-ic/IMAS-Data-Dictionary/actions/runs/14170012761/job/39691532601