### PR TITLE
Workaround to get PR number when triggered from fork

### DIFF
--- a/.github/workflows/pr_diff_comment_on_pr.yml
+++ b/.github/workflows/pr_diff_comment_on_pr.yml
@@ -14,6 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+    - name: 'Get PR number'
+      id: pr-context
+      env:
+        # The GH CLI uses this ENV for providing an auth token:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_TARGET_REPO: ${{ github.repository }}
+        PR_BRANCH: |-
+          ${{
+            (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+              && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+              || github.event.workflow_run.head_branch
+          }}
+      # Query the PR number by repo + branch, then assign to step output:
+      run: gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" --json 'number' --jq '"number=\(.number)"' >> "${GITHUB_OUTPUT}"
     - name: Comment on PR
       uses: actions/github-script@v7
       with:
@@ -27,7 +41,7 @@ jobs:
           })
           let job = jobs.data.jobs[jobs.data.jobs.length - 1]
           github.rest.issues.createComment({
-            issue_number: context.payload.workflow_run.pull_requests[0].number,
+            issue_number: ${{ steps.pr-context.outputs.number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: `[Diff of generated Data Dictionary XML file](${{ github.server_url }}/${{ github.repository }}/actions/runs/${context.payload.workflow_run.id}/attempts/${context.payload.workflow_run.run_attempt}#summary-${job.id})`


### PR DESCRIPTION
Previous solution didn't work for PRs from a forked repository, see [this failed run](https://github.com/iterorganization/IMAS-Data-Dictionary/actions/runs/14576674565/job/40884191945).

Solution in this PR is copied from https://github.com/orgs/community/discussions/25220#discussioncomment-11300118 and tested in https://github.com/maarten-ic/IMAS-Data-Dictionary/pull/3