### PR TITLE
Don't run publish-to-(test)pypi on forks

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -32,7 +32,7 @@ jobs:
         
   publish-to-pypi:
     name: Publish imas-data-dictionary distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'iterorganization'  # only publish to PyPI on tag pushes and not from forks
     needs:
     - build
     runs-on: ubuntu-22.04
@@ -52,7 +52,7 @@ jobs:
       
   publish-to-testpypi:
     name: Publish imas-data-dictionary distribution to TestPyPI
-    if: github.ref=='refs/heads/develop'  # only publish to TestPyPI on develop pushes
+    if: github.ref=='refs/heads/develop' && github.repository_owner == 'iterorganization'  # only publish to TestPyPI on develop pushes and not from forks
     needs:
     - build
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Update the publish_pypi workflow to skip the upload to pypi steps when running on a fork of the repository.

This should prevent CI failures when synchronizing the develop branch in forks, such as here: https://github.com/maarten-ic/IMAS-Data-Dictionary/actions/runs/14772761919