### PR TITLE
fixed locating IDSdef.xml

### DIFF
--- a/data_dictionary/idsinfo.py
+++ b/data_dictionary/idsinfo.py
@@ -64,12 +64,19 @@ class IDSInfo:
         self.idsdef_path = ""
         self.legacy_doc_path = ""
         self.sphinx_doc_path = ""
+        current_fpath = os.path.dirname(os.path.realpath(__file__))
         # Check idsdef.xml is installed in the Python environment (system as well as local)
         if not self.idsdef_path:
+            _idsdef_path_newer = os.path.join(current_fpath, r"../../../../")
+            _idsdef_path_old = os.path.join(current_fpath, r"../../../")
             local_path = os.path.join(str(Path.home()), ".local")
             python_env_list = [sys.prefix]
             if os.path.exists(local_path):
                 python_env_list.append(local_path)
+            if os.path.isfile(_idsdef_path_newer):
+                python_env_list.append(_idsdef_path_newer)
+            if os.path.isfile(_idsdef_path_old):
+                python_env_list.append(_idsdef_path_old)
             reg_compile = re.compile("dd_*")
             version_list = None
             python_env_path = ""
@@ -93,7 +100,6 @@ class IDSInfo:
 
         # Search through higher level directories
         if not self.idsdef_path:
-            current_fpath = os.path.dirname(os.path.realpath(__file__))
             # Newer approach : IMAS/<VERSION>/lib/python3.8/site-packages/data_dictionary/idsinfo.py
             _idsdef_path = os.path.join(current_fpath, r"../../../../include/IDSDef.xml")
             if os.path.isfile(_idsdef_path):


### PR DESCRIPTION
This PR fixes below issue
```bash
$ module load IMAS-Data-Dictionary/4.0.0-GCCcore-13.2.0

$ idsinfo idsnames
Traceback (most recent call last):
  File "/work/imas/opt/EasyBuild/software/IMAS-Data-Dictionary/4.0.0-GCCcore-13.2.0/bin/idsinfo", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/work/imas/opt/EasyBuild/software/IMAS-Data-Dictionary/4.0.0-GCCcore-13.2.0/lib/python3.11/site-packages/data_dictionary/idsinfo.py", line 346, in main
    idsinfoObj = IDSInfo()
                 ^^^^^^^^^
  File "/work/imas/opt/EasyBuild/software/IMAS-Data-Dictionary/4.0.0-GCCcore-13.2.0/lib/python3.11/site-packages/data_dictionary/idsinfo.py", line 150, in __init__
    raise Exception(
Exception: Error accessing IDSDef.xml.  Make sure its location is defined in your environment, e.g. byloading an IMAS module.
$ 
```