### PR TITLE
enable migration guide in read-the-docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,13 +7,13 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
-    
+
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: docs/requirements-changelog.txt
     - method: pip
       path: .
-      
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ language = "en"
 #
 # Note: these can be enabled/disabled to generate the IDS reference and changelog!
 #   For example: SPHINXOPTS="-D dd_changelog_generate=1 -D dd_autodoc_generate=1"
-dd_changelog_generate = False
+dd_changelog_generate = True
 dd_autodoc_generate = True
 
 

--- a/docs/requirements-changelog.txt
+++ b/docs/requirements-changelog.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+# To generate changelog
+imas_data_dictionaries
+imas_python

--- a/docs/sphinx_dd_extension/dd_changelog.py
+++ b/docs/sphinx_dd_extension/dd_changelog.py
@@ -29,9 +29,9 @@ except Exception as _:
     is_gitrepo = False
     
 try:
-    from imaspy import IDSFactory
-    from imaspy.dd_zip import dd_xml_versions
-    from imaspy.ids_convert import DDVersionMap
+    from imas import IDSFactory
+    from imas.dd_zip import dd_xml_versions
+    from imas.ids_convert import DDVersionMap
 
     has_imaspy = True
 except ImportError:


### PR DESCRIPTION
Essentially:
 - `dd_changelog_generate = True` 
 - rename `from imas import ...` (was `imaspy`)

And adding the extra requirements to `requirements-changelog.txt`

And tested in my fork's read-the-docs build:
 - https://louwrensth-imas-data-dictionary.readthedocs.io/en/feature-rtd-with-changelog/generated/changelog/ids.html#ids-migration-guide-to-4-0-1-dev165-g79195ab