### PR TITLE
[issue-102] Fix psi units for reflectometers

### DIFF
--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -1481,7 +1481,7 @@
 					<xs:documentation>Poloidal flux</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>W</units>
+						<units>Wb</units>
 						<coordinate1>1...N</coordinate1>
 						<coordinate1_same_as>../../n_e/data</coordinate1_same_as>
 						<coordinate2>../../n_e/time</coordinate2>


### PR DESCRIPTION
There was a typo in the units. A single change in utilities corrects all instances of this position structure