### PR TITLE
fix_coordinates_of_brightness_and_neutron_flux_in_neutron_diagnostics

### DIFF
--- a/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
+++ b/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
@@ -806,7 +806,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>m^-2.s^-1</units>
-						<coordinate1>../mode(1)/counting/time</coordinate1>
+						<coordinate1>/time</coordinate1>
 						<introduced_after_version>4.0.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>
@@ -820,7 +820,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>m^-2.s^-1</units>
-						<coordinate1>../mode(1)/counting/time</coordinate1>
+						<coordinate1>/time</coordinate1>
 						<introduced_after_version>4.0.0</introduced_after_version>
 					</xs:appinfo>
 				</xs:annotation>


### PR DESCRIPTION
Could you please verify coordinate information for `brightness `and `neutron_flux` in `neutron_diagnostics `IDS 
This is causing error as shown below
```bash
FATAL ERROR: time reference is not a double array
ERROR:root:b'al_begin_arraystruct_action: [ALBackendException = FATAL ERROR: time reference is not a double array]'
```
Should it be `/time` instead of `<coordinate1>../mode(1)/counting/time</coordinate1>`