### PR TITLE
Fix neutron_diagnostic fields reconstructed_emissivity: rho_tor_norm and psi_norm are constant

### DIFF
--- a/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
+++ b/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
@@ -72,10 +72,9 @@
 				<xs:annotation>
 					<xs:documentation>Normalized toroidal flux coordinate. The normalizing value for rho_tor_norm, is the toroidal flux coordinate at the equilibrium boundary (LCFS or 99.x % of the LCFS in case of a fixed boundary equilibium calculation, see time_slice/boundary in the equilibrium IDS)</xs:documentation>
 					<xs:appinfo>
-						<type>dynamic</type>
+						<type>constant</type>
 						<coordinate1>1...N</coordinate1>
 						<alternative_coordinate1>../psi_norm</alternative_coordinate1>
-						<coordinate2>/time</coordinate2>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
@@ -87,9 +86,8 @@
 				<xs:annotation>
 					<xs:documentation>Normalized poloidal flux coordinate for the reconstructed profiles, the flux being normalized to its value at the separatrix</xs:documentation>
 					<xs:appinfo>
-						<type>dynamic</type>
+						<type>constant</type>
 						<coordinate1>../rho_tor_norm</coordinate1>
-						<coordinate2>/time</coordinate2>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
+++ b/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
@@ -75,6 +75,7 @@
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>
 						<alternative_coordinate1>../psi_norm</alternative_coordinate1>
+						<coordinate2>/time</coordinate2>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
@@ -88,6 +89,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../rho_tor_norm</coordinate1>
+						<coordinate2>/time</coordinate2>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
+++ b/schemas/neutron_diagnostic/dd_neutron_diagnostic.xsd
@@ -84,7 +84,7 @@
 			</xs:element>
 			<xs:element name="psi_norm">
 				<xs:annotation>
-					<xs:documentation>Normalized poloidal flux coordinate for the reconstructed profiles, the flux being normalized to its value at the separatrix</xs:documentation>
+					<xs:documentation>Normalized poloidal flux coordinate for the reconstructed profiles, the flux being normalized to run from 0 at the magnetic axis to 1 at the separatrix</xs:documentation>
 					<xs:appinfo>
 						<type>constant</type>
 						<coordinate1>../rho_tor_norm</coordinate1>


### PR DESCRIPTION
https://github.com/iterorganization/IMAS-Data-Dictionary/pull/114#discussion_r2235757914

```bash
Traceback (most recent call last):
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/imas_test.py", line 42, in <module>
    neutron_diagnostic_test(configuration, test_settings, db_entry)
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/scripts/neutron_diagnostic_test.py", line 114, in neutron_diagnostic_test
    neutron_diagnostic_test_get_slice(test_settings, db_entry)
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/scripts/neutron_diagnostic_test.py", line 99, in neutron_diagnostic_test_get_slice
    neutron_diagnostic_ids_check(ids, test_settings, True, True, True, slice_idx);
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/scripts/neutron_diagnostic_check.py", line 2497, in neutron_diagnostic_ids_check
    check_reconstructed_emissivity(ids_node.reconstructed_emissivity, settings, check_static, check_dynamic, slice_mode, slice_idx)
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/scripts/neutron_diagnostic_check.py", line 2230, in check_reconstructed_emissivity
    assert_field(ids_node.rho_tor_norm, generate_value(settings, 'FLT', 1, True, slice_mode), 'reconstructed_emissivity/rho_tor_norm')
  File "/home/ITER/sawantp1/git/al-dev/al-python/build/tests/tester.py", line 18, in assert_field
    assert (observed.shape == expected.shape) and (observed == expected).all(), 'Field ' + fieldname + ': expected[shape=' + str(expected.shape) + '] = ' + str(expected) + ' observed[shape=' + str(observed.shape) + '] = ' + str(observed)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Field reconstructed_emissivity/rho_tor_norm: expected[shape=(1,)] = [386.66191981] observed[shape=(2,)] = [386.66191981 106.6945177 ]
````