### PR TITLE
Simplified description in summary IDS

### DIFF
--- a/schemas/summary/dd_summary.xsd
+++ b/schemas/summary/dd_summary.xsd
@@ -4282,21 +4282,9 @@
 						<xs:group ref="STR_0D"/>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="description_before">
+				<xs:element name="description">
 					<xs:annotation>
-						<xs:documentation>Description recorded when preparing a simulation or a pulse</xs:documentation>
-						<xs:appinfo>
-							<type>constant</type>
-							<introduced_after_version>4.0.0</introduced_after_version>
-						</xs:appinfo>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:group ref="STR_0D"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="description_after">
-					<xs:annotation>
-						<xs:documentation>Description of the outcome of the simulation or pulse, recorded after the end of a simulation or a pulse.</xs:documentation>
+						<xs:documentation>Description of the simulation or the pulse</xs:documentation>
 						<xs:appinfo>
 							<type>constant</type>
 							<introduced_after_version>4.0.0</introduced_after_version>


### PR DESCRIPTION
Proposed simplification of the `description` field of the summary IDS. 

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview imas-data-dictionary end -->