### PR TITLE
Improvement/issue 118 2

### DIFF
--- a/docs/dd_developer_guide.rst
+++ b/docs/dd_developer_guide.rst
@@ -769,6 +769,14 @@ It must have the following structure:
 The "name" and "description" attributes correspond to the "name" and "description" nodes in the DD identifier structure.
 The "index" is given by the int value.
 
+If the value of the identifier determines the units of other nodes in the IDS, this is documented by adding a <units_paths> tag below the <ddInstance> tag. The path of the related node is indicated relatively to the identifier node. If more than one node has its units determined by the value of the identifier, paths are separated by a comma. Example : <units_paths>../grid/dim1,../grid/dim2</units_paths>. Then, a "units" attribute is added for each possible identifier value, containing the actual units for this identifier value (separated by a comma in case of multiple nodes) e.g. : 
+
+.. code-block:: xml
+
+<int name="rectangular"
+     description="Cylindrical R,Z ala eqdsk (R=dim1, Z=dim2). In this case the position arrays should not be filled since they are redundant with grid/dim1 and dim2." units="m,m" 
+     >1</int> 
+
 For the sake of backward compatibility, it is possible to specify old values 
 of the "name" field by introducing at the corresponding line an "alias" attribute, 
 for example (below two aliases are given, separated by a comma):

--- a/docs/dd_developer_guide.rst
+++ b/docs/dd_developer_guide.rst
@@ -557,16 +557,16 @@ using the simpleTypes defined in utilities.xsd (named flt_type and flt_nd_type).
 
 .. code-block:: xml
 
-	<xs:element name="time" type="flt_1d_type">
-		<xs:annotation>
-			<xs:documentation>Generic time</xs:documentation>
-			<xs:appinfo>
-			<coordinate1>1...N</coordinate1>
-			<type>dynamic</type>
-			<units>s</units>
-			</xs:appinfo>
-		</xs:annotation>
-	</xs:element>
+   <xs:element name="time" type="flt_1d_type">
+      <xs:annotation>
+         <xs:documentation>Generic time</xs:documentation>
+         <xs:appinfo>
+            <coordinate1>1...N</coordinate1>
+            <type>dynamic</type>
+            <units>s</units>
+         </xs:appinfo>
+      </xs:annotation>
+   </xs:element>
 
 Simple structure node
 ~~~~~~~~~~~~~~~~~~~~~
@@ -755,16 +755,16 @@ It must have the following structure:
 
 .. code-block:: xml
 
-<?xml version="1.0"?>
-<constants name="equilibrium_profiles_2d_identifier" identifier="yes" create_mapping_function="yes">
-<header>Various contributions to the B, j, and psi 2D maps</header>
-<ddInstance xpath="/equilibrium/time_slice/profiles_2d/type"/>
-<int name="total" description="Total fields">0</int>
-<int name="vacuum" description="Vacuum fields (without contribution from plasma)">1</int>
-<int name="pf_active" description="Contribution from active coils only to the fields (pf_active IDS)">2</int>
-<int name="pf_passive" description="Contribution from passive elements only to the fields (pf_passive IDS)">3</int>
-<int name="plasma"  description="Plasma contribution to the fields">4</int>
-</constants>
+   <?xml version="1.0"?>
+   <constants name="equilibrium_profiles_2d_identifier" identifier="yes" create_mapping_function="yes">
+      <header>Various contributions to the B, j, and psi 2D maps</header>
+      <ddInstance xpath="/equilibrium/time_slice/profiles_2d/type"/>
+      <int name="total" description="Total fields">0</int>
+      <int name="vacuum" description="Vacuum fields (without contribution from plasma)">1</int>
+      <int name="pf_active" description="Contribution from active coils only to the fields (pf_active IDS)">2</int>
+      <int name="pf_passive" description="Contribution from passive elements only to the fields (pf_passive IDS)">3</int>
+      <int name="plasma"  description="Plasma contribution to the fields">4</int>
+   </constants>
 
 The "name" and "description" attributes correspond to the "name" and "description" nodes in the DD identifier structure.
 The "index" is given by the int value.
@@ -773,9 +773,9 @@ If the value of the identifier determines the units of other nodes in the IDS, t
 
 .. code-block:: xml
 
-<int name="rectangular"
-     description="Cylindrical R,Z ala eqdsk (R=dim1, Z=dim2). In this case the position arrays should not be filled since they are redundant with grid/dim1 and dim2." units="m,m" 
-     >1</int> 
+   <int name="rectangular"
+        description="Cylindrical R,Z ala eqdsk (R=dim1, Z=dim2). In this case the position arrays should not be filled since they are redundant with grid/dim1 and dim2."
+        units="m,m">1</int>
 
 For the sake of backward compatibility, it is possible to specify old values 
 of the "name" field by introducing at the corresponding line an "alias" attribute, 
@@ -783,7 +783,9 @@ for example (below two aliases are given, separated by a comma):
 
 .. code-block:: xml
 
-<int name="4He"  alias="4He,Helium_4"  description="Helium 4 isotope">30</int>
+   <int name="4He"
+        alias="4He,Helium_4"
+        description="Helium 4 isotope">30</int>
 
 
 .. _`dev alternative_coordinate1`:

--- a/docs/sphinx_dd_extension/autodoc.py
+++ b/docs/sphinx_dd_extension/autodoc.py
@@ -406,7 +406,7 @@ def identifier2rst(element: ElementTree.Element, fname: Path) -> str:
     """
     # Construct CSV
     csv_items = "\n".join(
-        f'"{ele.get("name")}","{ele.text}","{ele.get("description")}"'
+        f'"{ele.get("name")}","{ele.text}","{ele.get("description")}","{ele.get("units")}","{ele.get("alias")}"'
         for ele in element.iterfind("int")
     )
 
@@ -421,7 +421,7 @@ def identifier2rst(element: ElementTree.Element, fname: Path) -> str:
         result.append(line.strip())
     result.append("")
     result.append(".. csv-table::")
-    result.append(f'{INDENT}:header: "Name","Index","Description"')
+    result.append(f'{INDENT}:header: "Name","Index","Description","Units","Alias"')
     result.append("")
     result.append(indent(csv_items, INDENT))
     result.append("")

--- a/schemas/edge_profiles/dd_edge_profiles.xsd
+++ b/schemas/edge_profiles/dd_edge_profiles.xsd
@@ -348,7 +348,7 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Measured values</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>
@@ -392,7 +392,6 @@
 			<xs:element name="time_measurement_width">
 				<xs:annotation>
 					<xs:documentation>In case the measurements are averaged over a time interval, this node is the full width of this time interval (empty otherwise). In case the slicing/averaging method doesn't use a hard time interval cutoff, this width is the characteristic time span of the slicing/averaging method. By convention, the time interval starts at time_measurement-time_width and ends at time_measurement.</xs:documentation>
-					<!-- By convention, when this node has a positive value the time interval starts at time_measurement-time_width and ends at time_measurement. When it has a negative value -->
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>s</units>
@@ -456,7 +455,7 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>

--- a/schemas/plasma_profiles/dd_plasma_profiles.xsd
+++ b/schemas/plasma_profiles/dd_plasma_profiles.xsd
@@ -520,7 +520,7 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Measured values</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>
@@ -564,7 +564,6 @@
 			<xs:element name="time_measurement_width">
 				<xs:annotation>
 					<xs:documentation>In case the measurements are averaged over a time interval, this node is the full width of this time interval (empty otherwise). In case the slicing/averaging method doesn't use a hard time interval cutoff, this width is the characteristic time span of the slicing/averaging method. By convention, the time interval starts at time_measurement-time_width and ends at time_measurement.</xs:documentation>
-					<!-- By convention, when this node has a positive value the time interval starts at time_measurement-time_width and ends at time_measurement. When it has a negative value -->
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>s</units>
@@ -628,7 +627,7 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>

--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -2995,7 +2995,7 @@
 		<xs:sequence>
 			<xs:element name="measured">
 				<xs:annotation>
-					<xs:documentation>Measured values. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Measured values</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>
@@ -3039,7 +3039,6 @@
 			<xs:element name="time_measurement_width">
 				<xs:annotation>
 					<xs:documentation>In case the measurements are averaged over a time interval, this node is the full width of this time interval (empty otherwise). In case the slicing/averaging method doesn't use a hard time interval cutoff, this width is the characteristic time span of the slicing/averaging method. By convention, the time interval starts at time_measurement-time_width and ends at time_measurement.</xs:documentation>
-					<!-- By convention, when this node has a positive value the time interval starts at time_measurement-time_width and ends at time_measurement. When it has a negative value -->
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>s</units>
@@ -3090,7 +3089,7 @@
 			</xs:element>
 			<xs:element name="reconstructed">
 				<xs:annotation>
-					<xs:documentation>Value reconstructed from the fit. Units are: as_parent for a local measurement, as_parent.m for a line integrated measurement.</xs:documentation>
+					<xs:documentation>Value reconstructed from the fit</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<units>mixed</units>

--- a/schemas/utilities/materials_identifier.xml
+++ b/schemas/utilities/materials_identifier.xml
@@ -36,8 +36,8 @@ Materials used in the device mechanical structures
 <int name="HPGe"              description="High Purity Germanium">26</int>
 <int name="CeBr"              description="Cesium bromide">27</int>
 <int name="CZT"              description="Cadmium zinc telluride">28</int>
-<int name="115In"    alias="115In"          description="Indium 115 isotope">29</int>
-<int name="4He"  alias="4He"               description="Helium 4 isotope">30</int>
+<int name="115In"    alias="In_115"          description="Indium 115 isotope">29</int>
+<int name="4He"  alias="He_4"               description="Helium 4 isotope">30</int>
 
 
 </constants>

--- a/schemas/utilities/poloidal_plane_coordinates_identifier.xml
+++ b/schemas/utilities/poloidal_plane_coordinates_identifier.xml
@@ -4,116 +4,110 @@
 <ddInstance xpath="/equilibrium/time_slice/profiles_2d/grid_type"/>
 <ddInstance xpath="/mhd_linear/time_slice/toroidal_mode/vacuum/grid_type"/>
 <ddInstance xpath="/mhd_linear/time_slice/toroidal_mode/plasma/grid_type"/>
+<units_paths>../grid/dim1,../grid/dim2</units_paths>
 
 <int name="rectangular"
-     description="Cylindrical R,Z ala eqdsk (R=dim1, Z=dim2). In this case the position arrays should not be filled since they are redundant with grid/dim1 and dim2."
+     description="Cylindrical R,Z ala eqdsk (R=dim1, Z=dim2). In this case the position arrays should not be filled since they are redundant with grid/dim1 and dim2." units="m,m" 
      >1</int>
 <int name="inverse"
-     description="Rhopolar_polar 2D polar coordinates (rho=dim1, theta=dim2) with magnetic axis as centre of grid; the polar angle is theta= -atan2(z-zaxis,r-raxis)."
+     description="Rhopolar_polar 2D polar coordinates (rho=dim1, theta=dim2) with magnetic axis as centre of grid; the polar angle is theta= -atan2(z-zaxis,r-raxis)."  units="m,rad"
      >2</int>
 <int name="inverse_psi_straight_field_line"
-     description="Flux surface type with psi as radial label (dim1) and the straight-field line poloidal angle (mod(index,10)=1) (dim2); could be non-equidistant; magnetic axis as centre of grid"
+     description="Flux surface type with psi as radial label (dim1) and the straight-field line poloidal angle (mod(index,10)=1) (dim2); could be non-equidistant; magnetic axis as centre of grid"  units="Wb,rad"
      >11</int>
 <int name="inverse_psi_equal_arc"
-     description="Flux surface type with psi as radial label (dim1) and the equal arc poloidal angle (mod(index,10)=2) (dim2)"
+     description="Flux surface type with psi as radial label (dim1) and the equal arc poloidal angle (mod(index,10)=2) (dim2)"  units="Wb,rad"
      >12</int>
 <int name="inverse_psi_polar"
-     description="Flux surface type with psi as radial label (dim1) and the polar poloidal angle (mod(index,10)=3) (dim2); could be non-equidistant"
+     description="Flux surface type with psi as radial label (dim1) and the polar poloidal angle (mod(index,10)=3) (dim2); could be non-equidistant" units="Wb,rad"
      >13</int>
-
 <int name="inverse_psi_straight_field_line_fourier"
-     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the straight-field line poloidal angle (mod(index,10)=4) (dim2), could be non-equidistant; magnetic axis as centre of grid"
+     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the straight-field line poloidal angle (mod(index,10)=4) (dim2), could be non-equidistant; magnetic axis as centre of grid" units="Wb,1"
      >14</int>
 <int name="inverse_psi_equal_arc_fourier"
-     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the equal arc poloidal angle (mod(index,10)=5) (dim2)"
+     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the equal arc poloidal angle (mod(index,10)=5) (dim2)" units="Wb,1"
      >15</int>
 <int name="inverse_psi_polar_fourier"
-     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the polar poloidal angle (mod(index,10)=6) (dim2); could be non-equidistant"
+     description="Flux surface type with psi as radial label (dim1) and Fourier modes in the polar poloidal angle (mod(index,10)=6) (dim2); could be non-equidistant" units="Wb,1"
      >16</int>
-
 <int name="inverse_rhopolnorm_straight_field_line"
-     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the straight-field line poloidal angle (dim2)" units="1,rad"
      >21</int>
 <int name="inverse_rhopolnorm_equal_arc"
-     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the equal arc poloidal angle (dim2)" units="1,rad"
      >22</int>
 <int name="inverse_rhopolnorm_polar"
-     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and the polar poloidal angle (dim2)" units="1,rad"
      >23</int>
-
 <int name="inverse_rhopolnorm_straight_field_line_fourier"
-     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)" units="1,1"
      >24</int>
 <int name="inverse_rhopolnorm_equal_arc_fourier"
      description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and Fourier modes in the equal arc poloidal angle (dim2)"
-     >25</int>
+     units="1,1" >25</int>
 <int name="inverse_rhopolnorm_polar_fourier"
      description="Flux surface type with radial label sqrt[(psi-psi_axis)/(psi_edge-psi_axis)] (dim1) and Fourier modes in the polar poloidal angle (dim2)"
-     >26</int>
-
-
+      units="1,1" >26</int>
 <int name="inverse_rhotornorm_straight_field_line"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the straight-field line poloidal angle (dim2)"  units="1,rad"
      >31</int>
 <int name="inverse_rhotornorm_equal_arc"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the equal arc poloidal angle (dim2)" units="1,rad"
      >32</int>
 <int name="inverse_rhotornorm_polar"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and the polar poloidal angle (dim2)" units="1,rad"
      >33</int>
-
 <int name="inverse_rhotornorm_straight_field_line_fourier"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)" units="1,1"
      >34</int>
 <int name="inverse_rhotornorm_equal_arc_fourier"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the equal arc poloidal angle (dim2)" units="1,1"
      >35</int>
 <int name="inverse_rhotornorm_polar_fourier"
-     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/Phi_edge] (dim1) and Fourier modes in the polar poloidal angle (dim2)" units="1,1"
      >36</int>
-
 <int name="inverse_rhopol_straight_field_line"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the straight-field line poloidal angle (dim2)" units="Wb^-0.5,rad"
      >41</int>
 <int name="inverse_rhopol_equal_arc"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the equal arc poloidal angle (dim2)" units="Wb^-0.5,rad"
      >42</int>
 <int name="inverse_rhopol_polar"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and the polar poloidal angle (dim2)" units="Wb^-0.5,rad"
      >43</int>
 
 <int name="inverse_rhopol_straight_field_line_fourier"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the straight-field line poloidal angle (dim2)" units="Wb^-0.5,1"
      >44</int>
 <int name="inverse_rhopol_equal_arc_fourier"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the equal arc poloidal angle (dim2)" units="Wb^-0.5,1"
      >45</int>
 <int name="inverse_rhopol_polar_fourier"
-     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[psi-psi_axis] (dim1) and Fourier modes in the polar poloidal angle (dim2)" units="Wb^-0.5,1"
      >46</int>
 
 <int name="inverse_rhotor_straight_field_line"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the straight-field line poloidal angle (dim2)" units="m,rad"
      >51</int>
 <int name="inverse_rhotor_equal_arc"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the equal arc poloidal angle (dim2)" units="m,rad"
      >52</int>
 <int name="inverse_rhotor_polar"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and the polar poloidal angle (dim2)" units="m,rad"
      >53</int>
 
 <int name="inverse_rhotor_straight_field_line_fourier"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the straight-field line poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the straight-field line poloidal angle (dim2)" units="m,1"
      >54</int>
 <int name="inverse_rhotor_equal_arc_fourier"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the equal arc poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the equal arc poloidal angle (dim2)" units="m,1"
      >55</int>
 <int name="inverse_rhotor_polar_fourier"
-     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the polar poloidal angle (dim2)"
+     description="Flux surface type with radial label sqrt[Phi/pi/B0] (dim1), Phi being toroidal flux, and Fourier modes in the polar poloidal angle (dim2)" units="m,1"
      >56</int>
 
 <int name="irregular_rz_na"
-     description="Irregular grid, thus give list of vertices in dim1(1:ndim1), dim2(1:ndim1) and then all fields are on values(1:ndim1,1)"
+     description="Irregular grid, thus give list of vertices in dim1(1:ndim1), dim2(1:ndim1) and then all fields are on values(1:ndim1,1)" units="m,m"
      >91</int> <!-- Use only for R,Z and fill volume_element / needs to know if R,Z, psi,theta for dim1, dim2? Used with connect and only for rz -->
 
 </constants>


### PR DESCRIPTION
- Add an example of units in an identifier file (2D equilibrium maps)
- Calrify the situation of units for core_profile fits (they are really mixed, we can't now them)


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview imas-data-dictionary end -->