### PR TITLE
Run "test" workflow on PR changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: push
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-and-test-with-make:


### PR DESCRIPTION
Ensures that any issues covered by the "test" workflow are run and detected in the context of the PR.


For example, the `-` units remark in https://github.com/iterorganization/IMAS-Data-Dictionary/pull/161#pullrequestreview-3382883318 has been detected by the tests: https://github.com/imbeauf/IMAS-Data-Dictionary-5547/actions/runs/18773371512/job/53562318650 However, this test failure isn't shown in the PR overview.

This PR enables the tests workflow in Pull Requests, such that failing tests can be seen more easily.

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--162.org.readthedocs.build/en/162/

<!-- readthedocs-preview imas-data-dictionary end -->