### PR TITLE
Correct identifier XML paths when pushing to archive

### DIFF
--- a/.github/workflows/push-to-archive.yml
+++ b/.github/workflows/push-to-archive.yml
@@ -31,7 +31,8 @@ jobs:
         # Copy Data Dictionary definitions:
         cp IDSDef.xml '_destination/data-dictionary/${{ github.ref_name }}.xml'
         # Synchronize identifiers
-        cp -f schemas/*/*_identifier.xml _destination/identifiers
+        cd schemas
+        cp -f --parents */*_identifier.xml ../_destination/identifiers
     - name: Create PR
       env:
         GITHUB_TOKEN: ${{ secrets.IMAS_DATA_DICTIONARIES_SECRET }}


### PR DESCRIPTION
The identifier XMLs in https://github.com/iterorganization/IMAS-Data-Dictionaries/pull/8 all ended up in the `identifiers` folder. This commit fixes that problem and retains the original folder structure of the identifier XML files.

To be tested on the next release of the Data Dictionary 🤞 

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--174.org.readthedocs.build/en/174/

<!-- readthedocs-preview imas-data-dictionary end -->