### PR TITLE
Remove explicit indices in coordinates, replaced with "(:)" syntax to note "any indices" (#157)

### DIFF
--- a/dd_data_dictionary_validation.txt.xsl
+++ b/dd_data_dictionary_validation.txt.xsl
@@ -343,8 +343,12 @@ The utilities section has errors:<xsl:apply-templates select="./utilities//field
                 </xsl:when>
                 <!-- No validation for (itime), see IMAS-4675 -->
                 <xsl:when test="matches($index_with_parentheses, '^\(itime\)$')"/>
-                <!-- Explicit index >= 1 is also fine, e.g. in coordinate_system(process(i1)/coordinate_index)/coordinate(1) -->
-                <xsl:when test="matches($index_with_parentheses, '^\([1-9][0-9]*\)$')"/>
+                <!-- GH#157, don't allow explicit index -->
+                <xsl:when test="matches($index_with_parentheses, '^\([1-9][0-9]*\)$')">
+                    <xsl:apply-templates select=".">
+                        <xsl:with-param name="error_description" select="concat('Invalid ', $attr, ': `', $fullpath, '`. Explicit indices are not allowed in coordinates.')"/>
+                    </xsl:apply-templates>
+                </xsl:when>
                 <!-- The index refers to another node, e.g. coordinate_system(process(i1)/coordinate_index). Validate that path: -->
                 <xsl:when test="$index_with_parentheses">
                     <xsl:apply-templates select="." mode="validate_path">

--- a/dd_data_dictionary_validation.txt.xsl
+++ b/dd_data_dictionary_validation.txt.xsl
@@ -342,8 +342,9 @@ The utilities section has errors:<xsl:apply-templates select="./utilities//field
                     </xsl:if>
                 </xsl:when>
                 <!-- No validation for (itime), see IMAS-4675 -->
-                <xsl:when test="matches($index_with_parentheses, '^\(itime\)$')  or matches($index_with_parentheses, '^\(:\)$')"/>
-                <!-- GH#157, don't allow explicit index -->
+                <xsl:when test="matches($index_with_parentheses, '^\(itime\)$')"/>
+                <!-- GH#157, no validation for (:) and don't allow explicit index -->
+                <xsl:when test="matches($index_with_parentheses, '^\(:\)$')"/>
                 <xsl:when test="matches($index_with_parentheses, '^\([1-9][0-9]*\)$')">
                     <xsl:apply-templates select=".">
                         <xsl:with-param name="error_description" select="concat('Invalid ', $attr, ': `', $fullpath, '`. Explicit indices are not allowed in coordinates.')"/>

--- a/dd_data_dictionary_validation.txt.xsl
+++ b/dd_data_dictionary_validation.txt.xsl
@@ -342,7 +342,7 @@ The utilities section has errors:<xsl:apply-templates select="./utilities//field
                     </xsl:if>
                 </xsl:when>
                 <!-- No validation for (itime), see IMAS-4675 -->
-                <xsl:when test="matches($index_with_parentheses, '^\(itime\)$')"/>
+                <xsl:when test="matches($index_with_parentheses, '^\(itime\)$')  or matches($index_with_parentheses, '^\(:\)$')"/>
                 <!-- GH#157, don't allow explicit index -->
                 <xsl:when test="matches($index_with_parentheses, '^\([1-9][0-9]*\)$')">
                     <xsl:apply-templates select=".">

--- a/docs/coordinates.rst
+++ b/docs/coordinates.rst
@@ -10,6 +10,13 @@ the coordinate quantity. Alternatively, a coordinate can be a plain index, which
 is indicated as ``1...N`` when the size of the coordinate is variable or -- for
 example -- ``1...3`` when there is a strict number of items -- 3 in this case.
 
+When the path to a coordinate goes through an array of structure and
+the index of the array of structure is indicated as (:), it means that the coordinate 
+node must have the same size for all indices of its ancestor array of structure.
+Example: ``channel(i1)/camera(i2)/frame(:)/apparent_temperature`` in the camera_IR
+IDS indicates that ``apparent_temperature`` has the same size for all indices of the 
+``frame`` array of structure.
+
 Note that time coordinates are special due to the time slice functionality
 of the Access Layer. See the following section for more details.
 

--- a/schemas/camera_ir/dd_camera_ir.xsd
+++ b/schemas/camera_ir/dd_camera_ir.xsd
@@ -142,9 +142,9 @@
 					<xs:appinfo>
 						<type>static</type>
 						<coordinate1>1...N</coordinate1>
-						<coordinate1_same_as>../../frame(1)/apparent_temperature</coordinate1_same_as>
+						<coordinate1_same_as>../../frame(:)/apparent_temperature</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
-						<coordinate2_same_as>../../frame(1)/apparent_temperature</coordinate2_same_as>
+						<coordinate2_same_as>../../frame(:)/apparent_temperature</coordinate2_same_as>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -157,9 +157,9 @@
 					<xs:appinfo>
 						<type>static</type>
 						<coordinate1>1...N</coordinate1>
-						<coordinate1_same_as>../../frame(1)/apparent_temperature</coordinate1_same_as>
+						<coordinate1_same_as>../../frame(:)/apparent_temperature</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
-						<coordinate2_same_as>../../frame(1)/apparent_temperature</coordinate2_same_as>
+						<coordinate2_same_as>../../frame(:)/apparent_temperature</coordinate2_same_as>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -172,9 +172,9 @@
 					<xs:appinfo>
 						<type>static</type>
 						<coordinate1>1...N</coordinate1>
-						<coordinate1_same_as>../../frame(1)/apparent_temperature</coordinate1_same_as>
+						<coordinate1_same_as>../../frame(:)/apparent_temperature</coordinate1_same_as>
 						<coordinate2>1...N</coordinate2>
-						<coordinate2_same_as>../../frame(1)/apparent_temperature</coordinate2_same_as>
+						<coordinate2_same_as>../../frame(:)/apparent_temperature</coordinate2_same_as>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -257,7 +257,7 @@
 		<xs:sequence>
 			<xs:element name="apparent_temperature">
 				<xs:annotation>
-					<xs:documentation>Processed image in apparent temperature. First dimension : row index (horizontal orientation). Second dimension: column index (vertical orientation). The size of this matrix is assumed to be constant over time</xs:documentation>
+					<xs:documentation>Processed image in apparent temperature. First dimension : row index (horizontal orientation). Second dimension: column index (vertical orientation). The size of this matrix is assumed to be constant over time (i.e. same size for all frame indices)</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>1...N</coordinate1>


### PR DESCRIPTION


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--198.org.readthedocs.build/en/198/

<!-- readthedocs-preview imas-data-dictionary end -->