### PR TITLE
fix: correct units for unit vector and direction elements (dimensionless, not metres)

### DIFF
--- a/schemas/camera_ir/dd_camera_ir.xsd
+++ b/schemas/camera_ir/dd_camera_ir.xsd
@@ -348,7 +348,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="direction" type="xyz0d_static">
+			<xs:element name="direction" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Line of sight direction unit vector</xs:documentation>
 					<xs:appinfo>
@@ -356,7 +356,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="up" type="xyz0d_static">
+			<xs:element name="up" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Detector orientation unit vector</xs:documentation>
 					<xs:appinfo>

--- a/schemas/ec_launchers/dd_ec_launchers.xsd
+++ b/schemas/ec_launchers/dd_ec_launchers.xsd
@@ -273,7 +273,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="direction" type="xyz0d_static">
+			<xs:element name="direction" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Unit vector indicating the direction of the translation or the rotation axis at "home" position (i.e. ../../geometry/centre)</xs:documentation>
 					<xs:appinfo>

--- a/schemas/operational_instrumentation/dd_operational_instrumentation.xsd
+++ b/schemas/operational_instrumentation/dd_operational_instrumentation.xsd
@@ -9,7 +9,7 @@
 			<xs:documentation>Local frame for a rosette strain sensor</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -17,7 +17,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -25,7 +25,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the detector/aperture plane and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>
@@ -110,12 +110,12 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="direction" type="xyz0d_static">
+			<xs:element name="direction" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Direction of the measurement (unit vector)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="direction_second" type="xyz0d_static">
+			<xs:element name="direction_second" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Second direction of measurement, in case of a rosette straing gauge</xs:documentation>
 				</xs:annotation>

--- a/schemas/spectrometer_uv/dd_spectrometer_uv.xsd
+++ b/schemas/spectrometer_uv/dd_spectrometer_uv.xsd
@@ -182,7 +182,7 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the surface ( in case it is plane) and oriented towards the plasma.</xs:documentation>
 				</xs:annotation>
@@ -238,17 +238,17 @@
 					<xs:documentation>Position of the grating summit (defined as the point of contact of its concave side if the grating were put on a table). Used as the origin of the x1, x2, x3 vectors defined below</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is horizontal and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the grating at its summit and oriented towards the plasma.</xs:documentation>
 				</xs:annotation>

--- a/schemas/spectrometer_x_ray_crystal/dd_spectrometer_x_ray_crystal.xsd
+++ b/schemas/spectrometer_x_ray_crystal/dd_spectrometer_x_ray_crystal.xsd
@@ -314,7 +314,7 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -322,7 +322,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -330,7 +330,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the object surface and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>

--- a/schemas/spi/dd_spi.xsd
+++ b/schemas/spi/dd_spi.xsd
@@ -199,7 +199,7 @@
 			</xs:appinfo>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="direction" type="xyz0d_constant">
+			<xs:element name="direction" type="xyz0d_constant_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Unit vector of the cone direction</xs:documentation>
 				</xs:annotation>
@@ -209,12 +209,12 @@
 					<xs:documentation>Coordinates of the origin of the shatter cone</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="unit_vector_major" type="xyz0d_static">
+			<xs:element name="unit_vector_major" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Major unit vector describing the geometry of the elliptic shatter cone</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="unit_vector_minor" type="xyz0d_static">
+			<xs:element name="unit_vector_minor" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Minor unit vector describing the geometry of the elliptic shatter cone</xs:documentation>
 				</xs:annotation>
@@ -521,7 +521,7 @@
 					<xs:documentation>Description of the propellant gas</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="injection_direction" type="xyz0d_constant">
+			<xs:element name="injection_direction" type="xyz0d_constant_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Unit vector of the unshattered pellet velocity direction right before shattering</xs:documentation>
 				</xs:annotation>

--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -14118,14 +14118,17 @@
 
 	<xs:complexType name="xyz0d_dynamic_aos3_dimensionless">
 		<xs:annotation>
-			<xs:documentation>Structure for list of X, Y, Z components (0D, dynamic, within array of structures level 3, dimensionless). Used for unit vectors, direction vectors, and other dimensionless Cartesian triplets.</xs:documentation>
+			<xs:documentation>Structure for list of X, Y, Z components (0D, dynamic within an AoS3, dimensionless). Used for unit vectors, direction vectors, and other dimensionless Cartesian triplets.</xs:documentation>
+			<xs:appinfo>
+				<aos3Parent>yes</aos3Parent>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:sequence>
 			<xs:element name="x">
 				<xs:annotation>
 					<xs:documentation>Component along X axis</xs:documentation>
 					<xs:appinfo>
-						<type>dynamic_aos3</type>
+						<type>dynamic</type>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
@@ -14137,7 +14140,7 @@
 				<xs:annotation>
 					<xs:documentation>Component along Y axis</xs:documentation>
 					<xs:appinfo>
-						<type>dynamic_aos3</type>
+						<type>dynamic</type>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>
@@ -14149,7 +14152,7 @@
 				<xs:annotation>
 					<xs:documentation>Component along Z axis</xs:documentation>
 					<xs:appinfo>
-						<type>dynamic_aos3</type>
+						<type>dynamic</type>
 						<units>1</units>
 					</xs:appinfo>
 				</xs:annotation>

--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -14072,6 +14072,137 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
+	<xs:complexType name="xyz0d_static_dimensionless">
+		<xs:annotation>
+			<xs:documentation>Structure for list of X, Y, Z components (0D, static, dimensionless). Used for unit vectors, direction vectors, and other dimensionless Cartesian triplets.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="x">
+				<xs:annotation>
+					<xs:documentation>Component along X axis</xs:documentation>
+					<xs:appinfo>
+						<type>static</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="y">
+				<xs:annotation>
+					<xs:documentation>Component along Y axis</xs:documentation>
+					<xs:appinfo>
+						<type>static</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="z">
+				<xs:annotation>
+					<xs:documentation>Component along Z axis</xs:documentation>
+					<xs:appinfo>
+						<type>static</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="xyz0d_dynamic_aos3_dimensionless">
+		<xs:annotation>
+			<xs:documentation>Structure for list of X, Y, Z components (0D, dynamic, within array of structures level 3, dimensionless). Used for unit vectors, direction vectors, and other dimensionless Cartesian triplets.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="x">
+				<xs:annotation>
+					<xs:documentation>Component along X axis</xs:documentation>
+					<xs:appinfo>
+						<type>dynamic_aos3</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="y">
+				<xs:annotation>
+					<xs:documentation>Component along Y axis</xs:documentation>
+					<xs:appinfo>
+						<type>dynamic_aos3</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="z">
+				<xs:annotation>
+					<xs:documentation>Component along Z axis</xs:documentation>
+					<xs:appinfo>
+						<type>dynamic_aos3</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="xyz0d_constant_dimensionless">
+		<xs:annotation>
+			<xs:documentation>Structure for list of X, Y, Z components (0D, constant, dimensionless). Used for unit vectors, direction vectors, and other dimensionless Cartesian triplets.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="x">
+				<xs:annotation>
+					<xs:documentation>Component along X axis</xs:documentation>
+					<xs:appinfo>
+						<type>constant</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="y">
+				<xs:annotation>
+					<xs:documentation>Component along Y axis</xs:documentation>
+					<xs:appinfo>
+						<type>constant</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="z">
+				<xs:annotation>
+					<xs:documentation>Component along Z axis</xs:documentation>
+					<xs:appinfo>
+						<type>constant</type>
+						<units>1</units>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="FLT_0D"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="xyz1d_positions_static">
 		<xs:annotation>
 			<xs:documentation>Structure for list of X, Y, Z positions (1D, static)</xs:documentation>
@@ -14294,7 +14425,7 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -14302,7 +14433,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -14310,7 +14441,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the filter surface and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>
@@ -14464,7 +14595,7 @@
 			<xs:documentation>Dynamic description of X1, X2, X3 vectors for a planar object within an AoS type 3</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="x1_unit_vector" type="xyz0d_dynamic_aos3">
+			<xs:element name="x1_unit_vector" type="xyz0d_dynamic_aos3_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -14472,7 +14603,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_dynamic_aos3">
+			<xs:element name="x2_unit_vector" type="xyz0d_dynamic_aos3_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -14480,7 +14611,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_dynamic_aos3">
+			<xs:element name="x3_unit_vector" type="xyz0d_dynamic_aos3_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the detector/aperture plane and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>
@@ -14603,7 +14734,7 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -14611,7 +14742,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -14619,7 +14750,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the detector/aperture plane and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>
@@ -14743,7 +14874,7 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -14751,7 +14882,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -14759,7 +14890,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the object surface and oriented towards the plasma.</xs:documentation>
 					<xs:appinfo>
@@ -14936,17 +15067,17 @@
 					<xs:group ref="FLT_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the polarizer plane and oriented towards the plasma.</xs:documentation>
 				</xs:annotation>
@@ -15165,7 +15296,7 @@
 					<xs:documentation>Position of the camera centre</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x1_unit_vector" type="xyz0d_static">
+			<xs:element name="x1_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X1 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X1 vector is more horizontal than X2 (has a smaller abs(Z) component) and oriented in the positive phi direction (counter-clockwise when viewed from above). </xs:documentation>
 					<xs:appinfo>
@@ -15173,7 +15304,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x2_unit_vector" type="xyz0d_static">
+			<xs:element name="x2_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X2 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X2 axis is orthonormal so that uX2 = uX3 x uX1.</xs:documentation>
 					<xs:appinfo>
@@ -15181,7 +15312,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="x3_unit_vector" type="xyz0d_static">
+			<xs:element name="x3_unit_vector" type="xyz0d_static_dimensionless">
 				<xs:annotation>
 					<xs:documentation>Components of the X3 direction unit vector in the (X,Y,Z) coordinate system, where X is the major radius axis for phi = 0, Y is the major radius axis for phi = pi/2, and Z is the height axis. The X3 axis is normal to the camera plane and oriented towards the plasma.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
## Problem

Unit vectors, direction vectors, and orientation vectors in the Data Dictionary are currently tagged with `units="m"` (metres). These elements represent **dimensionless direction cosines** with magnitude 1 — they are *not* spatial coordinates.

The root cause is that unit vector elements (`x1_unit_vector`, `direction`, `up`, `injection_direction`, etc.) reference the same `xyz0d_static` / `xyz0d_dynamic_aos3` / `xyz0d_constant` templates as genuine position elements (`pinhole`, `target_surface_center`). These templates hardcode `<units>m</units>`, which is correct for positions but incorrect for direction cosines.

**Impact:** 1335 data paths across ~20 IDSs carry incorrect unit metadata. Any code that relies on DD units for unit conversion, dimensional analysis, or IMAS Standard Name generation will produce incorrect results for these quantities.

## Solution

Create three new **dimensionless** template variants in `dd_support.xsd`:
- `xyz0d_static_dimensionless` (units="1")
- `xyz0d_dynamic_aos3_dimensionless` (units="1")
- `xyz0d_constant_dimensionless` (units="1")

These are identical to the original templates except for the unit declaration. All unit vector and direction element references (37 total across 7 files) are updated to use the new templates. Position elements (`pinhole`, `target_surface_center`, `attachement_points`) correctly remain on the original metres-based templates.

## Changes

| File | Elements Updated | Count |
|------|-----------------|-------|
| `dd_support.xsd` | New templates + compound templates (filter_window, detector_aperture, curved_object, polarizer, camera_geometry, flat_object_orientation_aos3) | 18 refs + 3 templates |
| `dd_camera_ir.xsd` | direction, up | 2 |
| `dd_ec_launchers.xsd` | direction | 1 |
| `dd_operational_instrumentation.xsd` | x1/x2/x3_unit_vector, direction, direction_second | 5 |
| `dd_spectrometer_uv.xsd` | x1/x2/x3_unit_vector (×2 contexts) | 4 |
| `dd_spectrometer_x_ray_crystal.xsd` | x1/x2/x3_unit_vector | 3 |
| `dd_spi.xsd` | unit_vector_major, unit_vector_minor, direction, injection_direction | 4 |
| **Total** | | **37 refs** |

## Verification

Confirmed via static XSD analysis that:
- Zero unit_vector or direction elements remain on the old metres-based templates
- Only 3 genuine position elements (pinhole, target_surface_center, attachement_points) retain `units="m"`
- All direction element documentation strings confirm dimensionless semantics ("unit vector", "direction unit vector")
- Dimensionless unit follows the DD convention: `<units>1</units>` (542 existing uses across the DD)
- Cross-checked against `imas-python` IDSFactory output confirming the source bug is in the XSD, not downstream tooling

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--242.org.readthedocs.build/en/242/

<!-- readthedocs-preview imas-data-dictionary end -->