### PR TITLE
add utilities_aoscontext=yes for int_1d_time_1

### DIFF
--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -733,6 +733,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../../time</coordinate1>
+						<utilities_aoscontext>yes</utilities_aoscontext>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>
@@ -745,6 +746,7 @@
 					<xs:appinfo>
 						<type>dynamic</type>
 						<coordinate1>../../time</coordinate1>
+						<utilities_aoscontext>yes</utilities_aoscontext>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>


### PR DESCRIPTION
@imbeauf Could you please confirm this. Thank you

As per the documentation https://imas-data-dictionary.readthedocs.io/en/latest/dd_developer_guide.html#coordinates
adding `utilities_aos_context=yes` to `int_1d_time_1 `..

Should fix ITER CI issue..
```bash
build	02-Jun-2026 10:23:20	 --- --- --- Testing getSlice() on ece_imaging
build	02-Jun-2026 10:23:20	 --- --- --- --- occurence:            0
build	02-Jun-2026 10:23:20	 --- --- --- --- --- slice :            1
build	02-Jun-2026 10:23:20	FATAL ERROR: time reference is not a double array
build	02-Jun-2026 10:23:20	 al_begin_arraystruct_action: [ALBackendException = FATAL ERROR: time reference is not a double array]
build	02-Jun-2026 10:23:20	 ERROR! with field line_of_sight
build	02-Jun-2026 10:23:20	 ece_imaging:line_of_sight/points/first_point/r : ERROR: observed=  -9.0000000000000006E+040 , expected=   445.37160438154012   


build	02-Jun-2026 10:23:20	 --- --- --- Testing getSlice() on ece
build	02-Jun-2026 10:23:20	 --- --- --- --- occurence:            0
build	02-Jun-2026 10:23:20	 --- --- --- --- --- slice :            1
build	02-Jun-2026 10:23:20	FATAL ERROR: time reference is not a double array
build	02-Jun-2026 10:23:20	 al_begin_arraystruct_action: [ALBackendException = FATAL ERROR: time reference is not a double array]
build	02-Jun-2026 10:23:20	 ERROR! with field channel
build	02-Jun-2026 10:23:20	 ece:channel/name : ERROR: field is not associated!!!
```


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--258.org.readthedocs.build/en/258/

<!-- readthedocs-preview imas-data-dictionary end -->