### PR TITLE
[issue-235] Add missing NBC metadata

### DIFF
--- a/schemas/magnetics/dd_magnetics.xsd
+++ b/schemas/magnetics/dd_magnetics.xsd
@@ -573,6 +573,9 @@
 							<coordinate1>1...N</coordinate1>
 							<cocos_alias>bpol</cocos_alias>
 							<cocos_replace>b_field_pol</cocos_replace>
+							<change_nbc_version>3.24.0</change_nbc_version>
+							<change_nbc_description>aos_renamed</change_nbc_description>
+							<change_nbc_previous_name>bpol_probe</change_nbc_previous_name>
 						</xs:appinfo>
 					</xs:annotation>
 				</xs:element>


### PR DESCRIPTION
This missing metadata was reported in issue-235 ... although this addition alone will not solve the special case reported in issue-235, namely converting from a dataset using obsolescent nodes (specific conversion rules have been added in IMAS-Python).

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--269.org.readthedocs.build/en/269/

<!-- readthedocs-preview imas-data-dictionary end -->