### PR TITLE
fix(wall): neutral energy fluxes use energy type (W.m^-2), not particle type

### DIFF
--- a/schemas/wall/dd_wall.xsd
+++ b/schemas/wall/dd_wall.xsd
@@ -1186,7 +1186,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="neutral" type="wall_description_ggd_particle_neutral" maxOccurs="unbounded">
+			<xs:element name="neutral" type="wall_description_ggd_energy_neutral" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Neutral species fluxes</xs:documentation>
 					<xs:appinfo>
@@ -1209,7 +1209,7 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="neutral" type="wall_description_ggd_particle_neutral" maxOccurs="unbounded">
+			<xs:element name="neutral" type="wall_description_ggd_energy_neutral" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Neutral species fluxes</xs:documentation>
 					<xs:appinfo>


### PR DESCRIPTION
Fixes #272.

The `energy_fluxes` `kinetic` and `recombination` structures reached their neutral fluxes through `wall_description_ggd_particle_neutral`, so neutral energy fluxes inherited the particle-flux unit `m^-2.s^-1` instead of `W.m^-2` (the `electrons`/`ion` siblings already resolve to energy types). This retargets both `neutral` elements to the existing-but-unreferenced `wall_description_ggd_energy_neutral` (`W.m^-2`).

Scope: `energy_fluxes/{kinetic,recombination}/neutral`, `incident` + `emitted`, bare and `/state` — 8 leaves. Wired to the particle unit since the paths were introduced in **v3.38.0** (verified via the DD version history — no units change recorded since, so every release v3.38.0 → v4.1.1 and develop is affected). Metadata-only correction — the stored values were always energy fluxes.

**Backward-compatible, units-only.** `wall_description_ggd_energy_neutral` is structurally identical to `wall_description_ggd_particle_neutral`: same children (`element`, `name`, `ion_index`, `incident`, `emitted`, `multiple_states_flag`, `state`) and the same state fields (`name`, `vibrational_level`, `vibrational_mode`, `neutral_type`, `electron_configuration`, `incident`, `emitted`). The only differences are the `incident`/`emitted` `units` (`W.m^-2` vs `m^-2.s^-1`) and the correct energy type-level documentation. No field is added or removed — `z_min`/`z_max` are ion-only (`*_ion_state`) and appear on neither neutral type.