### PR TITLE
fix: GGD ionization_potential is an energy (eV), not a charge (e)

### DIFF
--- a/schemas/utilities/dd_support.xsd
+++ b/schemas/utilities/dd_support.xsd
@@ -11987,7 +11987,7 @@
 				<xs:annotation>
 					<xs:documentation>Cumulative and average ionization potential to reach a given bundle. Defined as sum (x_z* (sum of Epot from z'=0 to z-1)), where Epot is the ionization potential of ion Xz_+, and x_z is the relative concentration of a given charge state in the bundle, i.e. sum(x_z) = 1 over the bundle, given on various grid subsets</xs:documentation>
 					<xs:appinfo>
-						<units>e</units>
+						<units>eV</units>
 						<coordinate1>1...N</coordinate1>
 						<change_nbc_version>4.2.0</change_nbc_version>
 						<change_nbc_description>aos_renamed</change_nbc_description>


### PR DESCRIPTION
Fixes #277.

`ion/state/ionization_potential` is declared five times in DD 4.1.1. Four declare `eV`; the GGD copy in `dd_support.xsd` declares `e` (elementary charge). An ionisation potential is an energy, so the GGD declaration is dimensionally wrong — `[current]·[time]` instead of `[mass]·[length]²/[time]²` — and contradicts its own siblings.

The element sits directly beneath `z_min` / `z_max` / `z_average` / `z_square_average`, which are charge numbers legitimately annotated `e`; the `e` appears to have been carried down to the adjacent element.

## Change

One line, `schemas/utilities/dd_support.xsd:11990`:

```diff
-						<units>e</units>
+						<units>eV</units>
```

## Verification

- All five declarations of the quantity now declare `eV` (`dd_core_profiles.xsd:424`, `dd_support.xsd:3372`, `:9777`, `:11209`, `:11986`).
- The charge-number siblings in the same block (`z_min`, `z_max`, `z_average`, `z_square_average`) are unchanged and still declare `e`.
- `dd_support.xsd` parses as well-formed XML.
- Resolves 6 paths in 4.1.1: `edge_profiles` and `plasma_profiles` GGD, each as the struct-array plus its `values` and `coefficients` children.

Metadata-only correction — the stored values were always energies; only the declared unit was wrong.


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--280.org.readthedocs.build/en/280/

<!-- readthedocs-preview imas-data-dictionary end -->