### PR TITLE
fix: equilibrium constraint 'reconstructed' inherits its parent unit

### DIFF
--- a/schemas/equilibrium/dd_equilibrium.xsd
+++ b/schemas/equilibrium/dd_equilibrium.xsd
@@ -1207,7 +1207,7 @@
 					<xs:documentation>Value calculated from the reconstructed equilibrium</xs:documentation>
 					<xs:appinfo>
 						<type>dynamic</type>
-						<units>1</units>
+						<units>as_parent</units>
 					</xs:appinfo>
 				</xs:annotation>
 				<xs:complexType>


### PR DESCRIPTION
Fixes #278.

Each equilibrium constraint stores one physical quantity twice — as `measured` and as `reconstructed`. In `equilibrium_constraints_0D_position` the `reconstructed` element declares `units=1` (dimensionless) while its own `measured` and `sigma` siblings in the same `complexType` declare `as_parent`, so the pair is dimensionally inconsistent: for `n_e`, `measured` resolves to `m^-3` and `reconstructed` to dimensionless.

The four other equilibrium constraint complexTypes (`_0D`, `_0D_ip_like`, `_0D_b0_like`, `_0D_one_like`) all declare `as_parent` on `reconstructed`; this type was the only outlier.

## Change

One line, `schemas/equilibrium/dd_equilibrium.xsd:1210`:

```diff
-						<units>1</units>
+						<units>as_parent</units>
```

## Verification

- All five `reconstructed` declarations in `dd_equilibrium.xsd` now declare `as_parent` (lines 1210, 1315, 1423, 1531, 1636).
- `dd_equilibrium.xsd` parses as well-formed XML.
- Resolves the 5 constraints typed `equilibrium_constraints_0D_position`: `n_e` (`m^-3`), `pressure` and `pressure_rotational` (`Pa`), `j_phi` and `j_parallel` (`A.m^-2`) — their reconstructed values now inherit the quantity's unit, matching `measured`.

Metadata-only correction.


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--281.org.readthedocs.build/en/281/

<!-- readthedocs-preview imas-data-dictionary end -->