### PR TITLE
Improvement/imas 3243

### DIFF
--- a/html_documentation/dd_versions.html
+++ b/html_documentation/dd_versions.html
@@ -40,6 +40,7 @@
 				    <li>Fix some units in the SUMMARY IDS</li>
 				    <li>In the ECE IDS, separate out the definition of mode (new node) and harmonic (new definition for this node)</li>
 				    <li>Replace deltaw/name by an identifier deltaw/type in the NTMS IDS</li>
+				    <li>Make consistent the PULSE_SCHEDULE IDS for NBI and ICRH with the NBI and IC_ANTENNAS IDSs</li>
 				  </ul>
        </td>
       </tr>

--- a/schemas/pulse_schedule/dd_pulse_schedule.xsd
+++ b/schemas/pulse_schedule/dd_pulse_schedule.xsd
@@ -942,11 +942,13 @@
 					<xs:group ref="STR_0D"/>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="species" type="gas_mixture_constant" maxOccurs="3">
+			<xs:element name="species" type="plasma_composition_species">
 				<xs:annotation>
-					<xs:documentation>Species injected by the NBI unit (may be more than one in case the unit injects a gas mixture)</xs:documentation>
+					<xs:documentation>Injected species</xs:documentation>
 					<xs:appinfo>
-						<coordinate1>1...N</coordinate1>
+						<change_nbc_version>4.2.0</change_nbc_version>
+						<change_nbc_description>type_changed</change_nbc_description>
+						<change_nbc_previous_type>gas_mixture_constant AoS</change_nbc_previous_type>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>

--- a/schemas/pulse_schedule/dd_pulse_schedule.xsd
+++ b/schemas/pulse_schedule/dd_pulse_schedule.xsd
@@ -650,6 +650,64 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
+	<xs:complexType name="pulse_schedule_ic_antenna_module">
+		<xs:annotation>
+			<xs:documentation>IC antenna module</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="name">
+				<xs:annotation>
+					<xs:documentation>Short string identifier (unique for a given device)</xs:documentation>
+					<xs:appinfo>
+						<type>static</type>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="STR_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="description">
+				<xs:annotation>
+					<xs:documentation>Description, e.g. “top row, first module from the left when looking at the antenna from the plasma”</xs:documentation>
+					<xs:appinfo>
+						<type>static</type>
+					</xs:appinfo>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:group ref="STR_0D"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="power_type" type="identifier_static">
+				<xs:annotation>
+					<xs:documentation>Type of power used in the sibling power node (defining which power is referred to in this pulse_schedule). Index = 1: power_launched, 2: power_forward (see definitions in the ic_antennas  IDS)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="power" type="pulse_schedule_reference_ic">
+				<xs:annotation>
+					<xs:documentation>Power</xs:documentation>
+					<xs:appinfo>
+						<units>W</units>
+					</xs:appinfo>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="phase_forward" type="pulse_schedule_reference_ic">
+				<xs:annotation>
+					<xs:documentation>Phase of the forward power with respect to the first module</xs:documentation>
+					<xs:appinfo>
+						<units>rad</units>
+					</xs:appinfo>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="frequency" type="pulse_schedule_reference_ic">
+				<xs:annotation>
+					<xs:documentation>Frequency</xs:documentation>
+					<xs:appinfo>
+						<units>Hz</units>
+					</xs:appinfo>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="pulse_schedule_ic_antenna">
 		<xs:annotation>
 			<xs:documentation>IC antenna</xs:documentation>
@@ -691,19 +749,20 @@
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="phase" type="pulse_schedule_reference_ic">
+			<xs:element name="frequency" type="pulse_schedule_reference_ic">
 				<xs:annotation>
-					<xs:documentation>Phase</xs:documentation>
+					<xs:documentation>Frequency (average over modules)</xs:documentation>
 					<xs:appinfo>
-						<units>rad</units>
+						<units>Hz</units>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="frequency" type="pulse_schedule_reference_ic">
+			<xs:element name="module" type="pulse_schedule_ic_antenna_module" maxOccurs="8">
 				<xs:annotation>
-					<xs:documentation>Frequency</xs:documentation>
+					<xs:documentation>Set of antenna modules (each module is fed by a single transmission line)</xs:documentation>
 					<xs:appinfo>
-						<units>Hz</units>
+						<coordinate1>1...N</coordinate1>
+						<introduced_with_version>4.2.0</introduced_with_version>
 					</xs:appinfo>
 				</xs:annotation>
 			</xs:element>
@@ -1836,7 +1895,7 @@
 			<xs:appinfo>
 				<lifecycle_status>alpha</lifecycle_status>
 				<lifecycle_version>3.6.0</lifecycle_version>
-				<lifecycle_last_change>3.42.0</lifecycle_last_change>
+				<lifecycle_last_change>4.2.0</lifecycle_last_change>
 			</xs:appinfo>
 			<xs:appinfo/>
 		</xs:annotation>


### PR DESCRIPTION
This PR solves an old IMAS JIRA ticket https://jira.iter.org/browse/IMAS-3243?filter=-1 
This is to harmonize the Pulse schedule with the descriptions used in the NBI and IC_ANTENNAS IDSs:
For ICRH: add an antenna/module structure and remove the antenna/phase node
For NBI: replace the previous possibly multi-molecular species mixture by a single species per unit (and a single element species) to match the NBI IDS 

<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--288.org.readthedocs.build/en/288/

<!-- readthedocs-preview imas-data-dictionary end -->

<!-- xml-diff imas-data-dictionary start -->
----
📚 XML Diff 📚: https://scdimasdictionnarysa.z6.web.core.windows.net/pr-288/index.html

<!-- xml-diff imas-data-dictionary end -->