### PR TITLE
docs(waves): correct fast cumulative-power recipient

### DIFF
--- a/schemas/waves/dd_waves.xsd
+++ b/schemas/waves/dd_waves.xsd
@@ -966,7 +966,7 @@
 			</xs:element>
 			<xs:element name="power_inside_fast">
 				<xs:annotation>
-					<xs:documentation>Absorbed wave power on thermal species inside a flux surface (cumulative volume integral of the absorbed power density)</xs:documentation>
+					<xs:documentation>Absorbed wave power on the fast particle population inside a flux surface (cumulative volume integral of the absorbed power density)</xs:documentation>
 					<xs:appinfo>
 						<units>W</units>
 						<type>dynamic</type>
@@ -979,7 +979,7 @@
 			</xs:element>
 			<xs:element name="power_inside_fast_n_phi">
 				<xs:annotation>
-					<xs:documentation>Absorbed wave power on thermal species inside a flux surface (cumulative volume integral of the absorbed power density), per toroidal mode number</xs:documentation>
+					<xs:documentation>Absorbed wave power on the fast particle population inside a flux surface (cumulative volume integral of the absorbed power density), per toroidal mode number</xs:documentation>
 					<xs:appinfo>
 						<units>W</units>
 						<type>dynamic</type>


### PR DESCRIPTION
Closes #294

The ion-state `power_inside_fast` and `power_inside_fast_n_phi` descriptions
said the absorbed power lands on the *thermal* population, duplicating the
`power_inside_thermal` siblings and contradicting both their own names and the
neighbouring `power_density_fast`.

This corrects the recipient wording in both. Unit `W` and every type,
coordinate, path and dimensional attribute are unchanged; the XSD still parses.

Note: `waves_coherent_wave_profiles_1d_ion` carries the same wording on its
species-level `power_inside_fast` pair. Left out of scope here to match the
issue — happy to include it if you would prefer one change.


<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--295.org.readthedocs.build/en/295/

<!-- readthedocs-preview imas-data-dictionary end -->

<!-- xml-diff imas-data-dictionary start -->
----
📚 XML Diff 📚: https://scdimasdictionnarysa.z6.web.core.windows.net/pr-295/index.html

<!-- xml-diff imas-data-dictionary end -->